### PR TITLE
fix: unblock release builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -122,6 +122,95 @@ jobs:
             "https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gstreamer/master/linuxdeploy-plugin-gstreamer.sh" \
             "$tools_dir/linuxdeploy-plugin-gstreamer.sh"
 
+      - name: Pre-cache Tauri Windows bundler tools
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $toolsDir = Join-Path $env:LOCALAPPDATA 'tauri'
+          $nsisDir = Join-Path $toolsDir 'NSIS'
+          $pluginDir = Join-Path $nsisDir 'Plugins\x86-unicode\additional'
+          $nsisZip = Join-Path $env:RUNNER_TEMP 'nsis-3.11.zip'
+          $nsisUrl = 'https://github.com/tauri-apps/binary-releases/releases/download/nsis-3.11/nsis-3.11.zip'
+          $utilsUrl = 'https://github.com/tauri-apps/nsis-tauri-utils/releases/download/nsis_tauri_utils-v0.5.3/nsis_tauri_utils.dll'
+          $utilsDll = Join-Path $pluginDir 'nsis_tauri_utils.dll'
+          $expectedNsisHash = 'EF7FF767E5CBD9EDD22ADD3A32C9B8F4500BB10D'
+          $expectedUtilsHash = '75197FEE3C6A814FE035788D1C34EAD39349B860'
+
+          function Download-Retry([string] $Url, [string] $Destination) {
+            for ($attempt = 1; $attempt -le 5; $attempt++) {
+              try {
+                curl.exe --fail --location --retry 5 --retry-all-errors --retry-delay 2 `
+                  --connect-timeout 20 --max-time 300 --output $Destination $Url
+                if ($LASTEXITCODE -eq 0 -and (Test-Path $Destination) -and
+                    (Get-Item $Destination).Length -gt 0) {
+                  return
+                }
+              } catch {
+                if ($attempt -eq 5) {
+                  throw
+                }
+              }
+              Remove-Item -Force -ErrorAction SilentlyContinue $Destination
+              if ($attempt -eq 5) {
+                throw "Failed to download $Url"
+              }
+              Start-Sleep -Seconds (2 * $attempt)
+            }
+          }
+
+          $requiredFiles = @(
+            (Join-Path $nsisDir 'makensis.exe'),
+            (Join-Path $nsisDir 'Bin\makensis.exe'),
+            (Join-Path $nsisDir 'Stubs\lzma-x86-unicode'),
+            (Join-Path $nsisDir 'Stubs\lzma_solid-x86-unicode'),
+            (Join-Path $nsisDir 'Include\MUI2.nsh'),
+            (Join-Path $nsisDir 'Include\FileFunc.nsh'),
+            (Join-Path $nsisDir 'Include\x64.nsh'),
+            (Join-Path $nsisDir 'Include\nsDialogs.nsh'),
+            (Join-Path $nsisDir 'Include\WinMessages.nsh'),
+            (Join-Path $nsisDir 'Include\Win\COM.nsh'),
+            (Join-Path $nsisDir 'Include\Win\Propkey.nsh'),
+            (Join-Path $nsisDir 'Include\Win\RestartManager.nsh'),
+            $utilsDll
+          )
+
+          $missingFiles = @($requiredFiles | Where-Object { -not (Test-Path $_) })
+          if ($missingFiles.Count -gt 0) {
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $nsisDir
+            New-Item -ItemType Directory -Force -Path $toolsDir | Out-Null
+            Remove-Item -Force -ErrorAction SilentlyContinue $nsisZip
+            Download-Retry $nsisUrl $nsisZip
+            if ((Get-FileHash $nsisZip -Algorithm SHA1).Hash -ne $expectedNsisHash) {
+              throw "Unexpected NSIS archive checksum: $nsisZip"
+            }
+            Expand-Archive -Path $nsisZip -DestinationPath $toolsDir -Force
+            $extractedDir = Join-Path $toolsDir 'nsis-3.11'
+            if (-not (Test-Path $extractedDir)) {
+              throw "NSIS archive did not contain the expected directory: $extractedDir"
+            }
+            Move-Item -Force $extractedDir $nsisDir
+            New-Item -ItemType Directory -Force -Path $pluginDir | Out-Null
+          }
+
+          if (-not (Test-Path $utilsDll) -or
+              (Get-FileHash $utilsDll -Algorithm SHA1).Hash -ne $expectedUtilsHash) {
+            New-Item -ItemType Directory -Force -Path $pluginDir | Out-Null
+            Remove-Item -Force -ErrorAction SilentlyContinue $utilsDll
+            Download-Retry $utilsUrl $utilsDll
+          }
+
+          if ((Get-FileHash $utilsDll -Algorithm SHA1).Hash -ne $expectedUtilsHash) {
+            throw "Unexpected NSIS Tauri utils checksum: $utilsDll"
+          }
+
+          foreach ($requiredFile in $requiredFiles) {
+            if (-not (Test-Path $requiredFile)) {
+              throw "Missing Tauri Windows bundler tool: $requiredFile"
+            }
+          }
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -92,6 +92,36 @@ jobs:
             pkg-config \
             rpm
 
+      - name: Pre-cache Tauri Linux bundler tools
+        if: runner.os == 'Linux'
+        run: |
+          set -Eeuo pipefail
+          tools_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+          mkdir -p "$tools_dir"
+
+          download() {
+            local url="$1"
+            local destination="$2"
+            curl --fail --location --retry 5 --retry-all-errors --retry-delay 2 \
+              --connect-timeout 20 --max-time 300 \
+              "$url" --output "$destination"
+            test -s "$destination"
+            chmod +x "$destination"
+          }
+
+          download \
+            "https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-x86_64" \
+            "$tools_dir/AppRun-x86_64"
+          download \
+            "https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage" \
+            "$tools_dir/linuxdeploy-x86_64.AppImage"
+          download \
+            "https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh" \
+            "$tools_dir/linuxdeploy-plugin-gtk.sh"
+          download \
+            "https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gstreamer/master/linuxdeploy-plugin-gstreamer.sh" \
+            "$tools_dir/linuxdeploy-plugin-gstreamer.sh"
+
       - name: Install dependencies
         run: npm ci
 

--- a/app/listen/package-lock.json
+++ b/app/listen/package-lock.json
@@ -29,6 +29,7 @@
         "clsx": "^2.1.1",
         "gl-matrix": "^3.4.4",
         "leaflet": "^1.9.4",
+        "lodash-es": "^4.17.21",
         "lucide-react": "^1.7.0",
         "qrcode": "^1.5.4",
         "radix-ui": "^1.4.3",
@@ -4843,6 +4844,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.21",

--- a/app/listen/package.json
+++ b/app/listen/package.json
@@ -44,6 +44,7 @@
     "i18next-icu": "^2.4.4",
     "intl-messageformat": "^11.2.9",
     "leaflet": "^1.9.4",
+    "lodash-es": "^4.17.21",
     "qrcode": "^1.5.4",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",

--- a/app/listen/src/app-shell/AppRouter.bundle.test.tsx
+++ b/app/listen/src/app-shell/AppRouter.bundle.test.tsx
@@ -91,7 +91,7 @@ describe("AppRouter mobile bundle boundary", () => {
     ) as { dependencies?: Record<string, string> };
     expect(listenPackage.dependencies).not.toHaveProperty("lucide-react");
     expect(listenPackage.dependencies).not.toHaveProperty("iconoir-react");
-    expect(listenPackage.dependencies).not.toHaveProperty("lodash-es");
+    expect(listenPackage.dependencies).toHaveProperty("lodash-es", "^4.17.21");
 
     const viteConfig = readFileSync(
       path.join(process.cwd(), "vite.config.ts"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "i18next-icu": "^2.4.4",
         "intl-messageformat": "^11.2.9",
         "leaflet": "^1.9.4",
+        "lodash-es": "^4.17.21",
         "qrcode": "^1.5.4",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",


### PR DESCRIPTION
## Summary
- add `lodash-es` as a direct Listen dependency so the isolated Docker build resolves Nivo imports
- pre-cache Tauri Linux bundler tools with retries before packaging to avoid the AppRun downloader disconnect

## Validation
- `npm --workspace=app/listen run build`
- pre-commit hooks passed

This PR unblocks the post-merge Docker and Desktop release checks.