### PR TITLE
fix: restore Capacitor Artist Hero and Home rail images

### DIFF
--- a/app/crate/api/schemas/me.py
+++ b/app/crate/api/schemas/me.py
@@ -668,7 +668,7 @@ class HomeCardResponse(BaseModel):
 class HomeHeroSurfaceResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    mode: Literal["canonical", "legacy"]
+    mode: Literal["canonical"]
     artists: list[dict[str, Any]] = Field(default_factory=list)
 
 

--- a/app/crate/db/home_builder_discovery_queries.py
+++ b/app/crate/db/home_builder_discovery_queries.py
@@ -43,16 +43,39 @@ def _dedupe_home_hero_rows(rows: list[dict]) -> list[dict]:
     return deduped
 
 
+def _hero_source_dimensions(
+    item: Mapping[str, object], composition: str
+) -> tuple[object, object]:
+    width = item.get(f"_hero_{composition}_source_width")
+    height = item.get(f"_hero_{composition}_source_height")
+    has_composition_dimensions = any(
+        item.get(f"_hero_{candidate}_source_width") is not None
+        or item.get(f"_hero_{candidate}_source_height") is not None
+        for candidate in _CANONICAL_SURFACES
+    )
+    if has_composition_dimensions:
+        return width, height
+    return item.get("_hero_source_width"), item.get("_hero_source_height")
+
+
 def _add_hero_artwork_bounds(item: dict) -> None:
     generic_width = item.pop("_hero_source_width", None)
     generic_height = item.pop("_hero_source_height", None)
+    has_composition_dimensions = any(
+        item.get(f"_hero_{candidate}_source_width") is not None
+        or item.get(f"_hero_{candidate}_source_height") is not None
+        for candidate in _CANONICAL_SURFACES
+    )
     compositions: dict[str, dict] = {}
     for composition, output_size in (
         ("desktop", DESKTOP_HERO_SIZE),
         ("mobile", MOBILE_HERO_SIZE),
     ):
-        width = item.pop(f"_hero_{composition}_source_width", None) or generic_width
-        height = item.pop(f"_hero_{composition}_source_height", None) or generic_height
+        width = item.pop(f"_hero_{composition}_source_width", None)
+        height = item.pop(f"_hero_{composition}_source_height", None)
+        if not has_composition_dimensions:
+            width = width or generic_width
+            height = height or generic_height
         recipe = item.pop(f"_hero_{composition}_recipe", None)
         if not width or not height or not isinstance(recipe, Mapping):
             continue
@@ -90,10 +113,7 @@ def _canonical_surface_ready(item: Mapping[str, object], composition: str) -> bo
     ):
         return False
 
-    generic_width = item.get("_hero_source_width")
-    generic_height = item.get("_hero_source_height")
-    width = item.get(f"_hero_{composition}_source_width") or generic_width
-    height = item.get(f"_hero_{composition}_source_height") or generic_height
+    width, height = _hero_source_dimensions(item, composition)
     recipe = item.get(f"_hero_{composition}_recipe")
     return bool(
         width
@@ -205,13 +225,10 @@ def get_home_hero_bundle(
     surfaces = {}
     for composition in _CANONICAL_SURFACES:
         ready_names = ready_by_surface[composition]
-        if ready_names:
-            artists = [item for item in hero if item["name"] in ready_names]
-            mode = "canonical"
-        else:
-            artists = list(hero)
-            mode = "legacy"
-        surfaces[composition] = {"mode": mode, "artists": artists}
+        surfaces[composition] = {
+            "mode": "canonical",
+            "artists": [item for item in hero if item["name"] in ready_names],
+        }
 
     return {"hero": hero, "hero_surfaces": surfaces}
 

--- a/app/crate/media_access.py
+++ b/app/crate/media_access.py
@@ -126,6 +126,7 @@ def media_audience_for_path(path: str) -> MediaAudience | None:
         "/avatar",
         "/photo",
         "/background",
+        "/hero",
         "/image",
         "/images/",
         "/export",

--- a/app/listen/src/components/home/HomeDiscoverySections.test.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.test.tsx
@@ -557,7 +557,10 @@ describe("HomeTasteHero", () => {
       maskImage: "none",
     });
     expect(screen.getByTestId("mobile-hero-scrim")).toHaveClass("h-[82%]");
-    expect(screen.getByTestId("mobile-hero-intro-layout")).toHaveClass("top-0");
+    expect(screen.getByTestId("mobile-hero-intro-layout")).toHaveClass(
+      "top-0",
+      "pt-[calc(var(--listen-mobile-header-height)+0.5rem)]",
+    );
     expect(screen.getByText("Good morning")).toBeInTheDocument();
     expect(artistHeroApiUrl).toHaveBeenCalledWith(
       expect.objectContaining({ artistEntityUid: "artist-entity" }),

--- a/app/listen/src/components/home/HomeDiscoverySections.test.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.test.tsx
@@ -17,11 +17,7 @@ import type {
   HomeRadioStation,
   HomeRecentItem,
 } from "@/components/home/home-model";
-import {
-  artistBackgroundApiUrl,
-  artistHeroApiUrl,
-  artistPhotoApiUrl,
-} from "@/lib/library-routes";
+import { artistHeroApiUrl, artistPhotoApiUrl } from "@/lib/library-routes";
 import { renderWithListenProviders } from "@/test/render-with-listen-providers";
 
 vi.mock("@/lib/library-routes", async (importOriginal) => {
@@ -30,7 +26,6 @@ vi.mock("@/lib/library-routes", async (importOriginal) => {
     ...actual,
     artistPhotoApiUrl: vi.fn(actual.artistPhotoApiUrl),
     artistHeroApiUrl: vi.fn(actual.artistHeroApiUrl),
-    artistBackgroundApiUrl: vi.fn(actual.artistBackgroundApiUrl),
   };
 });
 
@@ -120,20 +115,20 @@ function heroFixture(overrides: Partial<HomeHeroArtist> = {}): HomeHeroArtist {
 }
 
 describe("HomeTasteHero", () => {
-  it("uses the legacy background when the surface is not canonically ready", () => {
+  it("does not render when the canonical surface has no available artists", () => {
     mockDesktopPointer();
 
     renderWithListenProviders(
       <HomeTasteHero
-        heroes={[heroFixture({ artwork_revision: "stale-revision" })]}
+        heroes={[heroFixture()]}
         heroSurfaces={{
           desktop: {
-            mode: "legacy",
-            artists: [heroFixture({ artwork_revision: "stale-revision" })],
+            mode: "canonical",
+            artists: [],
           },
           mobile: {
-            mode: "legacy",
-            artists: [heroFixture({ artwork_revision: "stale-revision" })],
+            mode: "canonical",
+            artists: [],
           },
         }}
         isFollowing={() => false}
@@ -143,12 +138,35 @@ describe("HomeTasteHero", () => {
       />,
     );
 
-    expect(artistBackgroundApiUrl).toHaveBeenCalled();
     expect(artistHeroApiUrl).not.toHaveBeenCalled();
-    expect(screen.getByTestId("desktop-legacy-hero")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("desktop-legacy-hero-artwork"),
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId("desktop-editorial-hero")).toBeNull();
+  });
+
+  it("does not render on mobile when the mobile surface has no available artists", () => {
+    mockMobilePointer();
+
+    renderWithListenProviders(
+      <HomeTasteHero
+        heroes={[heroFixture()]}
+        heroSurfaces={{
+          desktop: {
+            mode: "canonical",
+            artists: [heroFixture()],
+          },
+          mobile: {
+            mode: "canonical",
+            artists: [],
+          },
+        }}
+        isFollowing={() => false}
+        onOpenArtist={vi.fn()}
+        onPlay={vi.fn()}
+        onToggleFollow={vi.fn()}
+      />,
+    );
+
+    expect(artistHeroApiUrl).not.toHaveBeenCalled();
+    expect(screen.queryByRole("heading", { name: "Converge" })).toBeNull();
   });
 
   it("renders the editorial Just Landed content without recommendation controls", () => {
@@ -457,7 +475,7 @@ describe("HomeTasteHero", () => {
       <HomeTasteHero
         heroes={[
           heroFixture({
-            artwork_revision: "legacy-revision",
+            artwork_revision: "stale-revision",
             hero_compositions: {
               desktop: {
                 schema_version: 1,

--- a/app/listen/src/components/home/HomeDiscoverySections.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.tsx
@@ -21,8 +21,6 @@ import {
   Radio,
   Disc3,
   UserRound,
-  ChevronLeft,
-  ChevronRight,
   ChevronUp,
   ChevronDown,
 } from "@crate/ui/icons";
@@ -60,7 +58,6 @@ import { PlaylistArtwork } from "@/components/playlists/PlaylistArtwork";
 import {
   albumCoverApiUrl,
   albumPagePath,
-  artistBackgroundApiUrl,
   artistHeroApiUrl,
   artistPagePath,
   artistPhotoApiUrl,
@@ -299,28 +296,6 @@ function heroBackgroundSrc(
   return backgroundUrl || undefined;
 }
 
-function legacyHeroBackgroundSrc(
-  hero: HomeHeroArtist,
-  composition: "desktop" | "mobile",
-): string | undefined {
-  const backgroundUrl = artistBackgroundApiUrl(
-    {
-      artistId: hero.id,
-      artistEntityUid: hero.entity_uid,
-      artistSlug: hero.slug,
-      artistName: hero.name,
-    },
-    {
-      size:
-        composition === "desktop"
-          ? ARTIST_HERO_DESKTOP_SIZE.width
-          : ARTIST_HERO_MOBILE_SIZE.width,
-      version: HERO_BACKGROUND_VERSION,
-    },
-  );
-  return backgroundUrl || undefined;
-}
-
 function heroArtworkBounds(
   hero: HomeHeroArtist,
   composition: "desktop" | "mobile",
@@ -356,18 +331,13 @@ function useHeroBackgroundPreloader(
   heroes: HomeHeroArtist[],
   activeIndex: number,
   composition: "desktop" | "mobile",
-  mode: "canonical" | "legacy" = "canonical",
 ): void {
   const sources = useMemo(
     () =>
       heroes
-        .map((hero) =>
-          mode === "canonical"
-            ? heroBackgroundSrc(hero, composition)
-            : undefined,
-        )
+        .map((hero) => heroBackgroundSrc(hero, composition))
         .filter((src): src is string => Boolean(src)),
-    [composition, heroes, mode],
+    [composition, heroes],
   );
   const readyRef = useRef<Set<string>>(new Set());
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -470,14 +440,14 @@ export function HomeTasteHero({
   const isDesktop = useIsDesktop();
   const composition = isDesktop ? "desktop" : "mobile";
   const surface = heroSurfaces?.[composition];
-  const mode = surface?.mode ?? "canonical";
+  const surfaceArtists = heroSurfaces ? surface?.artists ?? [] : heroes;
   const surfaceHeroes = useMemo(
-    () => dedupeHeroArtists(surface?.artists ?? heroes),
-    [heroes, surface?.artists],
+    () => dedupeHeroArtists(surfaceArtists),
+    [surfaceArtists],
   );
   const count = surfaceHeroes.length;
   const activeIndex = Math.min(idx, Math.max(count - 1, 0));
-  useHeroBackgroundPreloader(surfaceHeroes, activeIndex, composition, mode);
+  useHeroBackgroundPreloader(surfaceHeroes, activeIndex, composition);
 
   useEffect(() => {
     setIdx((current) =>
@@ -490,19 +460,6 @@ export function HomeTasteHero({
   if (!isDesktop) {
     const hero = surfaceHeroes[0];
     if (!hero) return null;
-    if (mode === "legacy") {
-      return (
-        <LegacyMobileFeaturedArtist
-          hero={hero}
-          backgroundSrc={legacyHeroBackgroundSrc(hero, "mobile")}
-          following={isFollowing(hero.id)}
-          intro={mobileIntro}
-          onOpenArtist={() => onOpenArtist(hero)}
-          onPlay={() => onPlay(hero)}
-          onToggleFollow={() => onToggleFollow(hero)}
-        />
-      );
-    }
     return (
       <MobileFeaturedArtist
         hero={hero}
@@ -526,15 +483,12 @@ export function HomeTasteHero({
       className="relative mx-auto aspect-[1480/600] min-h-[clamp(480px,38dvh,600px)] w-full max-w-[1480px] overflow-hidden bg-app-surface"
     >
       {surfaceHeroes.map((hero, index) => {
-        const source =
-          mode === "canonical"
-            ? heroBackgroundSrc(hero, "desktop")
-            : legacyHeroBackgroundSrc(hero, "desktop");
+        const source = heroBackgroundSrc(hero, "desktop");
         const isPrepared =
           index === activeIndex ||
           index === (activeIndex + 1) % count ||
           index === (activeIndex - 1 + count) % count;
-        return mode === "canonical" ? (
+        return (
           <DesktopFeaturedArtist
             key={hero.entity_uid || hero.id}
             hero={hero}
@@ -545,42 +499,20 @@ export function HomeTasteHero({
             onPlay={() => onPlay(hero)}
             onToggleFollow={() => onToggleFollow(hero)}
           />
-        ) : (
-          <LegacyDesktopFeaturedArtist
-            key={hero.entity_uid || hero.id}
-            hero={hero}
-            active={index === activeIndex}
-            backgroundSrc={isPrepared ? source : undefined}
-            following={isFollowing(hero.id)}
-            intro={index === activeIndex ? desktopIntro : undefined}
-            onOpenArtist={() => onOpenArtist(hero)}
-            onPlay={() => onPlay(hero)}
-            onToggleFollow={() => onToggleFollow(hero)}
-          />
         );
       })}
 
       {count > 1 ? (
-        mode === "canonical" ? (
-          <DesktopHeroNavigation
-            heroes={surfaceHeroes}
-            activeIndex={activeIndex}
-            onPrevious={() => go(-1)}
-            onNext={() => go(1)}
-            onSelect={setIdx}
-          />
-        ) : (
-          <LegacyDesktopHeroNavigation
-            heroes={surfaceHeroes}
-            activeIndex={activeIndex}
-            onPrevious={() => go(-1)}
-            onNext={() => go(1)}
-            onSelect={setIdx}
-          />
-        )
+        <DesktopHeroNavigation
+          heroes={surfaceHeroes}
+          activeIndex={activeIndex}
+          onPrevious={() => go(-1)}
+          onNext={() => go(1)}
+          onSelect={setIdx}
+        />
       ) : null}
 
-      {mode === "canonical" && desktopIntro ? (
+      {desktopIntro ? (
         <div
           data-testid="desktop-hero-intro"
           className="pointer-events-none absolute inset-x-0 top-0 z-20"
@@ -590,215 +522,6 @@ export function HomeTasteHero({
           </div>
         </div>
       ) : null}
-    </div>
-  );
-}
-
-function LegacyMobileFeaturedArtist({
-  hero,
-  backgroundSrc,
-  following,
-  intro,
-  onOpenArtist,
-  onPlay,
-  onToggleFollow,
-}: {
-  hero: HomeHeroArtist;
-  backgroundSrc?: string;
-  following: boolean;
-  intro?: ReactNode;
-  onOpenArtist: () => void;
-  onPlay: () => void;
-  onToggleFollow: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <section
-      data-testid="mobile-legacy-hero"
-      className="relative h-[55dvh] min-h-[430px] max-h-[620px] w-full overflow-hidden rounded-none border-y border-white/10 bg-app-surface"
-    >
-      <LegacyHeroArtwork backgroundSrc={backgroundSrc} composition="mobile" />
-      <button
-        type="button"
-        aria-label={t("home.hero.openArtist", { name: hero.name })}
-        className="absolute inset-0 z-10 cursor-pointer"
-        onClick={onOpenArtist}
-      />
-      <div className="pointer-events-none relative z-20 flex h-full flex-col justify-between px-6 py-8">
-        <div className="pointer-events-none">{intro}</div>
-        <LegacyHeroCopy
-          hero={hero}
-          following={following}
-          onPlay={onPlay}
-          onToggleFollow={onToggleFollow}
-        />
-      </div>
-    </section>
-  );
-}
-
-function LegacyDesktopFeaturedArtist({
-  hero,
-  active,
-  backgroundSrc,
-  following,
-  intro,
-  onOpenArtist,
-  onPlay,
-  onToggleFollow,
-}: {
-  hero: HomeHeroArtist;
-  active: boolean;
-  backgroundSrc?: string;
-  following: boolean;
-  intro?: ReactNode;
-  onOpenArtist: () => void;
-  onPlay: () => void;
-  onToggleFollow: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <section
-      data-testid="desktop-legacy-hero"
-      aria-hidden={!active}
-      className={cn(
-        "absolute inset-0 overflow-hidden rounded-[12px] border border-white/10 transition-opacity duration-500 ease-out",
-        active ? "z-10 opacity-100" : "pointer-events-none z-0 opacity-0",
-      )}
-    >
-      <LegacyHeroArtwork backgroundSrc={backgroundSrc} composition="desktop" />
-      <button
-        type="button"
-        aria-label={t("home.hero.openArtist", { name: hero.name })}
-        tabIndex={active ? 0 : -1}
-        className="absolute inset-0 z-10 cursor-pointer"
-        onClick={onOpenArtist}
-      />
-      <div className="pointer-events-none relative z-20 flex h-full flex-col justify-between px-10 py-10">
-        <div className="pointer-events-none">{intro}</div>
-        <div className="max-w-[44%]">
-          <LegacyHeroCopy
-            hero={hero}
-            following={following}
-            onPlay={onPlay}
-            onToggleFollow={onToggleFollow}
-          />
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function LegacyHeroArtwork({
-  backgroundSrc,
-  composition,
-}: {
-  backgroundSrc?: string;
-  composition: "desktop" | "mobile";
-}) {
-  return (
-    <>
-      {backgroundSrc ? (
-        <CrateImage
-          data-testid={`${composition}-legacy-hero-artwork`}
-          src={backgroundSrc}
-          retryPolicy="eventual"
-          alt=""
-          aria-hidden="true"
-          decoding="async"
-          className="pointer-events-none absolute inset-0 h-full w-full object-cover object-top"
-        />
-      ) : null}
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,rgba(5,7,11,0.96)_0%,rgba(5,7,11,0.78)_42%,rgba(5,7,11,0.2)_100%)]" />
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(0deg,rgba(5,7,11,0.98)_0%,rgba(5,7,11,0.18)_60%,rgba(5,7,11,0.45)_100%)]" />
-    </>
-  );
-}
-
-function LegacyHeroCopy({
-  hero,
-  following,
-  onPlay,
-  onToggleFollow,
-}: {
-  hero: HomeHeroArtist;
-  following: boolean;
-  onPlay: () => void;
-  onToggleFollow: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <div className="pointer-events-auto">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-primary">
-        {t("home.library.justLanded.title")}
-      </p>
-      <h1 className="mt-2 truncate text-4xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
-        {hero.name}
-      </h1>
-      <HeroGenres hero={hero} />
-      <HeroActions
-        hero={hero}
-        following={following}
-        onPlay={onPlay}
-        onToggleFollow={onToggleFollow}
-      />
-    </div>
-  );
-}
-
-function LegacyDesktopHeroNavigation({
-  heroes,
-  activeIndex,
-  onPrevious,
-  onNext,
-  onSelect,
-}: {
-  heroes: HomeHeroArtist[];
-  activeIndex: number;
-  onPrevious: () => void;
-  onNext: () => void;
-  onSelect: (index: number) => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <div className="absolute inset-x-0 bottom-5 z-30 flex items-center justify-center gap-3">
-      <button
-        type="button"
-        aria-label={t("home.hero.previousArtist")}
-        className="flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/35 text-white/75 backdrop-blur-sm hover:text-white"
-        onClick={onPrevious}
-      >
-        <ChevronLeft size={18} />
-      </button>
-      <div className="flex items-center gap-1.5">
-        {heroes.map((hero, index) => (
-          <button
-            key={hero.entity_uid || hero.id}
-            type="button"
-            aria-label={t("home.hero.showArtist", { name: hero.name })}
-            aria-current={index === activeIndex ? "true" : undefined}
-            className="flex h-6 items-center bg-transparent px-1"
-            onClick={() => onSelect(index)}
-          >
-            <span
-              className={cn(
-                "block h-1.5 rounded-full transition-all duration-300",
-                index === activeIndex
-                  ? "w-6 bg-primary"
-                  : "w-1.5 bg-white/35 hover:bg-white/60",
-              )}
-            />
-          </button>
-        ))}
-      </div>
-      <button
-        type="button"
-        aria-label={t("home.hero.nextArtist")}
-        className="flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/35 text-white/75 backdrop-blur-sm hover:text-white"
-        onClick={onNext}
-      >
-        <ChevronRight size={18} />
-      </button>
     </div>
   );
 }

--- a/app/listen/src/components/home/HomeDiscoverySections.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.tsx
@@ -686,6 +686,7 @@ function MobileFeaturedArtist({
           kicker={t("home.library.justLanded.title")}
           artistName={hero.name}
           intro={intro}
+          mobileIntroClassName="pt-[calc(var(--listen-mobile-header-height)+0.5rem)]"
           genres={<HeroGenres hero={hero} />}
           actions={
             <HeroActions

--- a/app/listen/src/components/layout/Shell.test.tsx
+++ b/app/listen/src/components/layout/Shell.test.tsx
@@ -158,14 +158,14 @@ describe("Shell", () => {
     );
   });
 
-  it("keeps the existing mobile Home header chrome", () => {
+  it("overlays the mobile Home header on the hero", () => {
     const { container } = renderWithListenProviders(<Shell />, { route: "/" });
 
     expect(screen.getByTestId("listen-header")).toHaveAttribute(
       "data-home-overlay",
-      "false",
+      "true",
     );
     expect(container.querySelector(".listen-home-top-scrim")).toBeNull();
-    expect(screen.getByTestId("listen-content")).not.toHaveClass("pt-0");
+    expect(screen.getByTestId("listen-content")).toHaveClass("pt-0");
   });
 });

--- a/app/listen/src/components/layout/Shell.tsx
+++ b/app/listen/src/components/layout/Shell.tsx
@@ -443,15 +443,17 @@ export function Shell() {
   const overlayHeader = hasOverlayHeader(location.pathname, location.search);
   const homePage = location.pathname === "/";
   const homeDesktopOverlay = isDesktop && homePage;
+  const homeMobileOverlay = !isDesktop && homePage;
   const desktopOverlayHeader = overlayHeader || homeDesktopOverlay;
   const collectionActive =
     location.pathname === "/library" ||
     location.pathname.startsWith("/collection");
   const headerOffsetClass = desktopOverlayHeader ? "" : "pt-24";
   const desktopContentPadClass = desktopOverlayHeader ? "pt-0 pb-6" : "py-6";
-  const mobileContentPadClass = overlayHeader
-    ? "pt-0 pb-4"
-    : "py-4 pt-[var(--listen-mobile-page-top)]";
+  const mobileContentPadClass =
+    overlayHeader || homeMobileOverlay
+      ? "pt-0 pb-4"
+      : "py-4 pt-[var(--listen-mobile-page-top)]";
   const headerChromeClass =
     "border-b border-white/6 bg-app-surface/68 shadow-[0_12px_32px_rgba(0,0,0,0.18)] backdrop-blur-xl";
   const overlayHeaderChromeClass = desktopOverlayHeader
@@ -519,9 +521,11 @@ export function Shell() {
     <div className="flex min-h-screen flex-col bg-app-surface">
       <div
         data-testid="listen-header"
-        data-home-overlay="false"
+        data-home-overlay={String(homeMobileOverlay)}
         className={`z-app-header fixed top-0 left-0 right-0 ${
-          overlayHeader ? "bg-transparent" : headerChromeClass
+          overlayHeader || homeMobileOverlay
+            ? "bg-transparent"
+            : headerChromeClass
         }`}
         style={{ paddingTop: "var(--listen-safe-top)" }}
       >

--- a/app/shared/ui/domain/ArtistHeroFrame.test.tsx
+++ b/app/shared/ui/domain/ArtistHeroFrame.test.tsx
@@ -117,6 +117,7 @@ describe("ArtistHeroPresentation", () => {
         artistName="Converge"
         intro={<span>Good afternoon</span>}
         actions={<span>Play</span>}
+        mobileIntroClassName="pt-[calc(var(--listen-mobile-header-height)+0.5rem)]"
       />,
     );
 
@@ -124,7 +125,7 @@ describe("ArtistHeroPresentation", () => {
     expect(screen.getByTestId("mobile-hero-intro-layout")).toHaveClass(
       "top-0",
       "px-5",
-      "pt-4",
+      "pt-[calc(var(--listen-mobile-header-height)+0.5rem)]",
     );
     expect(screen.getByText("Good afternoon")).toBeInTheDocument();
     expect(screen.getByTestId("mobile-hero-copy-layout")).toHaveClass(

--- a/app/shared/ui/domain/ArtistHeroPresentation.tsx
+++ b/app/shared/ui/domain/ArtistHeroPresentation.tsx
@@ -13,6 +13,7 @@ interface ArtistHeroPresentationProps {
   className?: string;
   copyClassName?: string;
   actionsClassName?: string;
+  mobileIntroClassName?: string;
 }
 
 export function ArtistHeroPresentation({
@@ -25,6 +26,7 @@ export function ArtistHeroPresentation({
   className,
   copyClassName,
   actionsClassName,
+  mobileIntroClassName,
 }: ArtistHeroPresentationProps) {
   const mobile = composition === "mobile";
   const copy = (
@@ -70,7 +72,10 @@ export function ArtistHeroPresentation({
       {mobile && intro ? (
         <div
           data-testid="mobile-hero-intro-layout"
-          className="absolute inset-x-0 top-0 px-5 pt-4"
+          className={cn(
+            "absolute inset-x-0 top-0 px-5",
+            mobileIntroClassName ?? "pt-4",
+          )}
         >
           {intro}
         </div>

--- a/app/shared/web/artist-hero-contract.ts
+++ b/app/shared/web/artist-hero-contract.ts
@@ -1,7 +1,7 @@
 export const ARTIST_HERO_CONTRACT_VERSION = 1 as const;
 
 export type ArtistHeroComposition = "desktop" | "mobile";
-export type HomeHeroMode = "canonical" | "legacy";
+export type HomeHeroMode = "canonical";
 
 export interface HomeHeroSurface<TArtist = unknown> {
   mode: HomeHeroMode;

--- a/app/tests/test_home_hero_scoring.py
+++ b/app/tests/test_home_hero_scoring.py
@@ -305,11 +305,11 @@ def test_home_hero_bundle_selects_ready_artists_per_surface(monkeypatch):
 
     desktop_only = _prepared_hero_row("Desktop Ready", mobile=False)
     mobile_only = _prepared_hero_row("Mobile Ready", desktop=False)
-    legacy = _hero_row("Legacy Fallback", listeners=900)
+    unavailable = _hero_row("Unavailable Candidate", listeners=900)
     monkeypatch.setattr(
         queries,
         "get_home_hero_rows",
-        lambda **_: [desktop_only, mobile_only, legacy],
+        lambda **_: [desktop_only, mobile_only, unavailable],
     )
     monkeypatch.setattr(queries, "get_artist_genres_map", lambda _names: {})
 
@@ -326,7 +326,35 @@ def test_home_hero_bundle_selects_ready_artists_per_surface(monkeypatch):
     ] == ["Mobile Ready"]
 
 
-def test_home_hero_bundle_uses_legacy_surface_until_manual_approved_artwork_is_ready(
+def test_home_hero_bundle_skips_artist_without_mobile_source(monkeypatch):
+    from crate.db import home_builder_discovery_queries as queries
+
+    desktop_only = _prepared_hero_row("Birds In Row")
+    desktop_only.update(
+        {
+            "_hero_desktop_source_width": 1400,
+            "_hero_desktop_source_height": 700,
+            "_hero_mobile_source_width": None,
+            "_hero_mobile_source_height": None,
+        }
+    )
+    mobile_ready = _prepared_hero_row("Mobile Ready")
+    monkeypatch.setattr(
+        queries,
+        "get_home_hero_rows",
+        lambda **_: [desktop_only, mobile_ready],
+    )
+    monkeypatch.setattr(queries, "get_artist_genres_map", lambda _names: {})
+
+    bundle = queries.get_home_hero_bundle(7, [], [], [])
+
+    assert bundle is not None
+    assert [
+        artist["name"] for artist in bundle["hero_surfaces"]["mobile"]["artists"]
+    ] == ["Mobile Ready"]
+
+
+def test_home_hero_bundle_hides_surfaces_without_manual_approved_artwork(
     monkeypatch,
 ):
     from crate.db import home_builder_discovery_queries as queries
@@ -343,18 +371,17 @@ def test_home_hero_bundle_uses_legacy_surface_until_manual_approved_artwork_is_r
     bundle = queries.get_home_hero_bundle(7, [], [], [])
 
     assert bundle is not None
-    for surface in ("desktop", "mobile"):
-        assert bundle["hero_surfaces"][surface]["mode"] == "legacy"
-        assert [
-            artist["name"] for artist in bundle["hero_surfaces"][surface]["artists"]
-        ] == ["Derived Candidate", "Pending Candidate"]
+    assert bundle["hero_surfaces"]["desktop"]["mode"] == "canonical"
+    assert bundle["hero_surfaces"]["desktop"]["artists"] == []
+    assert bundle["hero_surfaces"]["mobile"]["mode"] == "canonical"
+    assert bundle["hero_surfaces"]["mobile"]["artists"] == []
 
 
 def test_home_hero_surface_rotation_keeps_surface_modes(monkeypatch):
     from crate.db import home_discovery_surface as surface
 
     payload = {
-        "hero": [{"id": 1, "name": "Legacy"}],
+        "hero": [{"id": 1, "name": "Unavailable"}],
         "hero_surfaces": {
             "desktop": {
                 "mode": "canonical",
@@ -364,7 +391,7 @@ def test_home_hero_surface_rotation_keeps_surface_modes(monkeypatch):
                 ],
             },
             "mobile": {
-                "mode": "legacy",
+                "mode": "canonical",
                 "artists": [{"id": 3, "name": "Three"}],
             },
         },
@@ -382,4 +409,4 @@ def test_home_hero_surface_rotation_keeps_surface_modes(monkeypatch):
     assert [
         artist["name"] for artist in rotated["hero_surfaces"]["desktop"]["artists"]
     ] == ["Two", "One"]
-    assert rotated["hero_surfaces"]["mobile"]["mode"] == "legacy"
+    assert rotated["hero_surfaces"]["mobile"]["mode"] == "canonical"

--- a/app/tests/test_media_access_tickets.py
+++ b/app/tests/test_media_access_tickets.py
@@ -107,6 +107,7 @@ def test_media_ticket_cannot_be_reused_for_another_path_in_the_same_audience(
         ("/api/auth/users/7/avatar", "artwork"),
         ("/api/artists/12/photo", "artwork"),
         ("/api/artists/12/background", "artwork"),
+        ("/api/artists/12/hero?composition=mobile", "artwork"),
         ("/api/me/contributions/4/export", "artwork"),
         ("/api/tracks/12/stream", "stream"),
         ("/api/stream/Band/Album/Song.flac", "stream"),
@@ -188,6 +189,10 @@ def test_ticket_endpoint_issues_requested_browser_media_paths(
                     path="/api/albums/12/cover",
                 ),
                 MediaAccessTargetRequest(
+                    audience="artwork",
+                    path="/api/artists/12/hero?composition=mobile",
+                ),
+                MediaAccessTargetRequest(
                     audience="stream",
                     path="/api/tracks/12/stream",
                 ),
@@ -197,6 +202,7 @@ def test_ticket_endpoint_issues_requested_browser_media_paths(
 
     assert [(item.audience, item.path) for item in response.tickets] == [
         ("artwork", "/api/albums/12/cover"),
+        ("artwork", "/api/artists/12/hero"),
         ("stream", "/api/tracks/12/stream"),
     ]
     assert all(item.ticket for item in response.tickets)


### PR DESCRIPTION
## Qué cambia

- Clasifica /api/artists/{id}/hero como media artwork para que Capacitor emita correctamente los tickets del Hero y de los rails del Home.
- Selecciona artistas canónicos de forma independiente para desktop y mobile.
- Excluye artistas sin la composición requerida; por ejemplo, un artista con solo hero desktop no se usa en mobile.
- Elimina por completo el fallback al hero legacy en desktop y mobile: si una superficie no tiene artistas disponibles, no se renderiza ningún hero.
- Ajusta Home mobile para que el hero empiece a sangre bajo una cabecera transparente y el saludo quede visible dentro del hero.

## Por qué

La regresión de media access hacía fallar el batch inicial de tickets en Capacitor y dejaba imágenes del Hero y de los rails sin cargar. Además, el fallback legacy podía mostrar una imagen incorrecta cuando no existía un Hero canónico. En mobile, la cabecera reservaba espacio fuera del hero y desplazaba el full bleed y el saludo.

## Validación

- uv run pytest -q app/tests/test_home_hero_scoring.py app/tests/test_media_access_tickets.py — 40 passed
- Tests relevantes de app/listen — 204 passed
- HomeDiscoverySections y Shell — 40 passed
- ArtistHeroFrame — 4 passed
- ESLint y Ruff OK
- Hooks pre-commit OK
- Typecheck lanzado; el proceso quedó bloqueado por carga del entorno y fue detenido