### PR TITLE
fix: stabilize artist hero and home artwork

### DIFF
--- a/app/crate/db/home_builder_discovery_queries.py
+++ b/app/crate/db/home_builder_discovery_queries.py
@@ -28,6 +28,7 @@ from crate.utils import coerce_int
 
 HOME_JUST_LANDED_VERSION = "home_just_landed_v2"
 HOME_HERO_CANDIDATE_LIMIT = 15
+HOME_HERO_SELECTED_LIMIT = 8
 _CANONICAL_SURFACES = ("desktop", "mobile")
 
 
@@ -159,7 +160,7 @@ def _rank_home_hero_rows(
     )
     ranked_rows = score_home_hero_rows(rows) if personalized else rows
     ranked_rows = _dedupe_home_hero_rows(ranked_rows)
-    selected_rows = ranked_rows[:5]
+    selected_rows = ranked_rows[:HOME_HERO_SELECTED_LIMIT]
 
     record_home_hero_debug(
         {

--- a/app/listen/src/components/artwork/CrateImage.test.tsx
+++ b/app/listen/src/components/artwork/CrateImage.test.tsx
@@ -139,6 +139,24 @@ describe("CrateImage", () => {
     expect(image).toHaveAttribute("data-artwork-state", "ready");
   });
 
+  it("keeps ready protected artwork visible during a ticket gap with eventual retries", () => {
+    const artwork = source("high-vis", "one", "eventual");
+    const { rerender } = render(<CrateImage source={artwork} alt="High Vis" />);
+    const image = screen.getByRole("img", { name: "High Vis" });
+    fireEvent.load(image);
+
+    versions.usable = false;
+    versions.tickets = 2;
+    rerender(<CrateImage source={artwork} alt="High Vis" />);
+
+    expect(screen.getByRole("img", { name: "High Vis" })).toBe(image);
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/artists/high-vis/photo?v=one&media_ticket=1",
+    );
+    expect(image).toHaveAttribute("data-artwork-state", "ready");
+  });
+
   it("updates responsive sizes without replacing the visible bitmap", () => {
     const artwork = { ...source("high-vis", "one"), sizes: "100px" };
     const { rerender } = render(<CrateImage source={artwork} alt="High Vis" />);

--- a/app/listen/src/components/artwork/CrateImage.tsx
+++ b/app/listen/src/components/artwork/CrateImage.tsx
@@ -115,6 +115,9 @@ export function CrateImage({
       sizes,
     });
   }, [rawSource, retryPolicy, sizes, srcSet]);
+  const isTicketedArtwork = requiresMediaAccessTicket(artwork.src);
+  const preservesReadyArtwork =
+    artwork.retryPolicy === "credentials" || isTicketedArtwork;
   const resolved = useMemo(
     () => resolveArtworkCandidate(artwork),
     // ticketVersion intentionally re-registers protected paths. Content
@@ -154,7 +157,7 @@ export function CrateImage({
     desiredRef.current = desired;
     const current = activeRef.current;
     if (!resolved) {
-      if (current?.ready && artwork.retryPolicy === "credentials") return;
+      if (current?.ready && preservesReadyArtwork) return;
       commit(null);
       return;
     }
@@ -181,12 +184,12 @@ export function CrateImage({
     return () => {
       cancelled = true;
     };
-  }, [artwork, resolved]);
+  }, [artwork, preservesReadyArtwork, resolved]);
 
   useEffect(() => {
     if (handledResumeVersion.current === resumeVersion) return;
     handledResumeVersion.current = resumeVersion;
-    if (!artwork.src || artwork.retryPolicy !== "credentials") return;
+    if (!artwork.src || !preservesReadyArtwork) return;
     const wasReady = Boolean(activeRef.current?.ready);
     if (wasReady && !shouldRefreshAfterResume(imageRef.current, loading)) {
       return;
@@ -218,10 +221,10 @@ export function CrateImage({
     return () => {
       cancelled = true;
     };
-  }, [artwork, loading, resumeVersion]);
+  }, [artwork, loading, preservesReadyArtwork, resumeVersion]);
 
   const displayed = !resolved
-    ? active?.ready && artwork.retryPolicy === "credentials"
+    ? active?.ready && preservesReadyArtwork
       ? active
       : null
     : !active || active.candidate.logicalKey !== resolved.logicalKey

--- a/app/listen/src/components/home/HomeDiscoverySections.test.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.test.tsx
@@ -1,5 +1,13 @@
 import { act, fireEvent, screen, within } from "@testing-library/react";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import {
   EssentialsSection,
@@ -93,11 +101,16 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  vi.spyOn(Math, "random").mockReturnValue(0);
   Object.defineProperty(navigator, "maxTouchPoints", {
     configurable: true,
     value: 0,
   });
   mockDesktopPointer();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 function heroFixture(overrides: Partial<HomeHeroArtist> = {}): HomeHeroArtist {
@@ -185,7 +198,8 @@ describe("HomeTasteHero", () => {
       />,
     );
 
-    expect(screen.getByText("Just landed")).toBeInTheDocument();
+    expect(screen.getByText("Featured Artist")).toBeInTheDocument();
+    expect(screen.queryByText("Just landed")).toBeNull();
     expect(screen.queryByText("Recommended")).toBeNull();
     expect(screen.getByTitle("Hardcore")).toHaveClass("rounded-md");
     expect(screen.getByText("hardcore")).toBeInTheDocument();
@@ -227,6 +241,33 @@ describe("HomeTasteHero", () => {
     fireEvent.click(screen.getByRole("button", { name: "Next artist" }));
 
     expect(screen.getByRole("heading", { name: "Botch" })).toBeInTheDocument();
+  });
+
+  it("starts the desktop carousel at a random artist", () => {
+    mockDesktopPointer();
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.75);
+
+    try {
+      renderWithListenProviders(
+        <HomeTasteHero
+          heroes={[
+            heroFixture(),
+            heroFixture({ id: 8, name: "Botch" }),
+            heroFixture({ id: 9, name: "Mastodon" }),
+          ]}
+          isFollowing={() => false}
+          onOpenArtist={vi.fn()}
+          onPlay={vi.fn()}
+          onToggleFollow={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: "Mastodon" }),
+      ).toBeInTheDocument();
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   it("does not repeat the same artist in the desktop carousel", () => {
@@ -287,7 +328,7 @@ describe("HomeTasteHero", () => {
     );
   });
 
-  it("keeps the Just landed kicker tight to the artist name", () => {
+  it("keeps the Featured Artist kicker tight to the artist name", () => {
     mockDesktopPointer();
 
     renderWithListenProviders(
@@ -300,7 +341,7 @@ describe("HomeTasteHero", () => {
       />,
     );
 
-    expect(screen.getByText("Just landed")).toHaveClass("leading-none");
+    expect(screen.getByText("Featured Artist")).toHaveClass("leading-none");
     expect(screen.getByRole("heading", { name: "Converge" })).toHaveClass(
       "mt-1",
     );
@@ -507,7 +548,7 @@ describe("HomeTasteHero", () => {
     });
   });
 
-  it("renders only the newest artist and no carousel interaction on mobile", () => {
+  it("renders the initial artist without carousel controls on mobile", () => {
     mockMobilePointer();
 
     renderWithListenProviders(
@@ -570,6 +611,37 @@ describe("HomeTasteHero", () => {
     expect(
       screen.queryByTestId("mobile-hero-edge-scrim"),
     ).not.toBeInTheDocument();
+  });
+
+  it("rotates through the available mobile artists", () => {
+    mockMobilePointer();
+    vi.useFakeTimers();
+
+    try {
+      renderWithListenProviders(
+        <HomeTasteHero
+          heroes={[heroFixture(), heroFixture({ id: 8, name: "Botch" })]}
+          isFollowing={() => false}
+          onOpenArtist={vi.fn()}
+          onPlay={vi.fn()}
+          onToggleFollow={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: "Converge" }),
+      ).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(8_000);
+      });
+
+      expect(
+        screen.getByRole("heading", { name: "Botch" }),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not autoplay the desktop carousel", () => {

--- a/app/listen/src/components/home/HomeDiscoverySections.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.tsx
@@ -436,7 +436,6 @@ export function HomeTasteHero({
   desktopIntro?: ReactNode;
   mobileIntro?: ReactNode;
 }) {
-  const [idx, setIdx] = useState(0);
   const isDesktop = useIsDesktop();
   const composition = isDesktop ? "desktop" : "mobile";
   const surface = heroSurfaces?.[composition];
@@ -446,7 +445,11 @@ export function HomeTasteHero({
     [surfaceArtists],
   );
   const count = surfaceHeroes.length;
+  const [idx, setIdx] = useState(() =>
+    isDesktop && count > 1 ? Math.floor(Math.random() * count) : 0,
+  );
   const activeIndex = Math.min(idx, Math.max(count - 1, 0));
+  const desktopInitialIndexSet = useRef(isDesktop && count > 1);
   useHeroBackgroundPreloader(surfaceHeroes, activeIndex, composition);
 
   useEffect(() => {
@@ -455,10 +458,24 @@ export function HomeTasteHero({
     );
   }, [surfaceHeroes.length]);
 
+  useEffect(() => {
+    if (!isDesktop || count <= 1 || desktopInitialIndexSet.current) return;
+    desktopInitialIndexSet.current = true;
+    setIdx(Math.floor(Math.random() * count));
+  }, [count, isDesktop]);
+
+  useEffect(() => {
+    if (isDesktop || count <= 1) return;
+    const interval = window.setInterval(() => {
+      setIdx((current) => (current + 1) % count);
+    }, 8_000);
+    return () => window.clearInterval(interval);
+  }, [count, isDesktop]);
+
   if (!count) return null;
 
   if (!isDesktop) {
-    const hero = surfaceHeroes[0];
+    const hero = surfaceHeroes[activeIndex];
     if (!hero) return null;
     return (
       <MobileFeaturedArtist
@@ -683,7 +700,7 @@ function MobileFeaturedArtist({
         />
         <ArtistHeroPresentation
           composition="mobile"
-          kicker={t("home.library.justLanded.title")}
+          kicker={t("home.hero.featuredArtist")}
           artistName={hero.name}
           intro={intro}
           mobileIntroClassName="pt-[calc(var(--listen-mobile-header-height)+0.5rem)]"
@@ -751,7 +768,7 @@ function DesktopFeaturedArtist({
         />
         <ArtistHeroPresentation
           composition="desktop"
-          kicker={t("home.library.justLanded.title")}
+          kicker={t("home.hero.featuredArtist")}
           artistName={hero.name}
           genres={<HeroGenres hero={hero} />}
           actions={

--- a/app/listen/src/i18n/catalogs/ca.json
+++ b/app/listen/src/i18n/catalogs/ca.json
@@ -286,6 +286,7 @@
   "explore.moods.subtitle": "Impulsat per l'anàlisi d'àudio de la teva biblioteca.",
   "explore.moods.mixName": "Mix {mood}",
   "home.hero.notInterested": "No m'interessa",
+  "home.hero.featuredArtist": "Artista destacat",
   "home.hero.previousArtist": "Artista anterior",
   "home.hero.nextArtist": "Artista següent",
   "home.hero.showArtist": "Mostra {name}",

--- a/app/listen/src/i18n/catalogs/de.json
+++ b/app/listen/src/i18n/catalogs/de.json
@@ -286,6 +286,7 @@
   "explore.moods.subtitle": "Angetrieben durch Audioanalyse deiner Bibliothek.",
   "explore.moods.mixName": "{mood}-Mix",
   "home.hero.notInterested": "Nicht interessiert",
+  "home.hero.featuredArtist": "Vorgestellter Künstler",
   "home.hero.previousArtist": "Vorheriger Künstler",
   "home.hero.nextArtist": "Nächster Künstler",
   "home.hero.showArtist": "{name} anzeigen",

--- a/app/listen/src/i18n/catalogs/en.json
+++ b/app/listen/src/i18n/catalogs/en.json
@@ -286,6 +286,7 @@
   "explore.moods.subtitle": "Powered by audio analysis of your library.",
   "explore.moods.mixName": "{mood} Mix",
   "home.hero.notInterested": "Not interested",
+  "home.hero.featuredArtist": "Featured Artist",
   "home.hero.previousArtist": "Previous artist",
   "home.hero.nextArtist": "Next artist",
   "home.hero.showArtist": "Show {name}",

--- a/app/listen/src/i18n/catalogs/es.json
+++ b/app/listen/src/i18n/catalogs/es.json
@@ -286,6 +286,7 @@
   "explore.moods.subtitle": "Impulsado por el análisis de audio de tu biblioteca.",
   "explore.moods.mixName": "Mix {mood}",
   "home.hero.notInterested": "No me interesa",
+  "home.hero.featuredArtist": "Artista destacado",
   "home.hero.previousArtist": "Artista anterior",
   "home.hero.nextArtist": "Artista siguiente",
   "home.hero.showArtist": "Mostrar {name}",

--- a/app/listen/src/i18n/catalogs/eu.json
+++ b/app/listen/src/i18n/catalogs/eu.json
@@ -286,6 +286,7 @@
   "explore.moods.subtitle": "Zure liburutegiaren audio-analisiak bultzatuta.",
   "explore.moods.mixName": "{mood} mixa",
   "home.hero.notInterested": "Ez zait interesatzen",
+  "home.hero.featuredArtist": "Artista nabarmendua",
   "home.hero.previousArtist": "Aurreko artista",
   "home.hero.nextArtist": "Hurrengo artista",
   "home.hero.showArtist": "Erakutsi {name}",

--- a/app/listen/src/i18n/catalogs/fr.json
+++ b/app/listen/src/i18n/catalogs/fr.json
@@ -286,6 +286,7 @@
   "explore.moods.subtitle": "Propulsé par l'analyse audio de ta bibliothèque.",
   "explore.moods.mixName": "Mix {mood}",
   "home.hero.notInterested": "Pas intéressé",
+  "home.hero.featuredArtist": "Artiste à l'honneur",
   "home.hero.previousArtist": "Artiste précédent",
   "home.hero.nextArtist": "Artiste suivant",
   "home.hero.showArtist": "Afficher {name}",

--- a/app/listen/src/i18n/catalogs/it.json
+++ b/app/listen/src/i18n/catalogs/it.json
@@ -286,6 +286,7 @@
   "explore.moods.subtitle": "Basato sull'analisi audio della tua libreria.",
   "explore.moods.mixName": "Mix {mood}",
   "home.hero.notInterested": "Non mi interessa",
+  "home.hero.featuredArtist": "Artista in evidenza",
   "home.hero.previousArtist": "Artista precedente",
   "home.hero.nextArtist": "Artista successivo",
   "home.hero.showArtist": "Mostra {name}",

--- a/app/listen/src/pages/Home.test.tsx
+++ b/app/listen/src/pages/Home.test.tsx
@@ -184,7 +184,7 @@ describe("Home", () => {
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
-  it("keeps Custom mixes and Just landed out of the desktop home", () => {
+  it("keeps Custom mixes and the library rail out of the desktop home", () => {
     viewportState.isDesktop = true;
     vi.mocked(useApi).mockReturnValue({
       data: homeDiscoveryPayloadWithDiscoveryRails(),
@@ -196,7 +196,8 @@ describe("Home", () => {
     renderWithListenProviders(<Home />);
 
     expect(screen.queryByText("Custom mixes")).toBeNull();
-    expect(screen.getAllByText("Just landed")).toHaveLength(1);
+    expect(screen.getByText("Featured Artist")).toBeInTheDocument();
+    expect(screen.queryByText("Just landed")).toBeNull();
   });
 
   it("composes the desktop greeting inside the hero without overlapping the rails", () => {
@@ -229,7 +230,7 @@ describe("Home", () => {
     ).toBeNull();
   });
 
-  it("shows Just landed on the mobile home", () => {
+  it("shows the featured artist and Just landed rail on the mobile home", () => {
     vi.mocked(useApi).mockReturnValue({
       data: homeDiscoveryPayloadWithDiscoveryRails(),
       loading: false,
@@ -239,7 +240,8 @@ describe("Home", () => {
 
     renderWithListenProviders(<Home />);
 
-    expect(screen.getAllByText("Just landed")).toHaveLength(2);
+    expect(screen.getByText("Featured Artist")).toBeInTheDocument();
+    expect(screen.getByText("Just landed")).toBeInTheDocument();
   });
 
   it("does not treat the featured artist as a recommendation surface", () => {

--- a/app/tests/test_home_hero_scoring.py
+++ b/app/tests/test_home_hero_scoring.py
@@ -326,6 +326,58 @@ def test_home_hero_bundle_selects_ready_artists_per_surface(monkeypatch):
     ] == ["Mobile Ready"]
 
 
+def test_home_hero_bundle_selects_up_to_eight_desktop_artists(monkeypatch):
+    from crate.db import home_builder_discovery_queries as queries
+
+    desktop_ready = [
+        _prepared_hero_row(f"Desktop Ready {index}", mobile=False) for index in range(8)
+    ]
+    monkeypatch.setattr(
+        queries,
+        "get_home_hero_rows",
+        lambda **_: desktop_ready,
+    )
+    monkeypatch.setattr(queries, "get_artist_genres_map", lambda _names: {})
+
+    bundle = queries.get_home_hero_bundle(7, [], [], [])
+
+    assert bundle is not None
+    assert [
+        artist["name"] for artist in bundle["hero_surfaces"]["desktop"]["artists"]
+    ] == [f"Desktop Ready {index}" for index in range(8)]
+
+
+def test_home_hero_bundle_does_not_lose_ready_desktop_artists_to_fallbacks(
+    monkeypatch,
+):
+    from crate.db import home_builder_discovery_queries as queries
+
+    fallback_candidates = [
+        {
+            **_hero_row(f"Fallback {index}", listeners=100),
+            "is_followed": True,
+            "user_play_count": 20,
+        }
+        for index in range(2)
+    ]
+    desktop_ready = [
+        _prepared_hero_row(f"Desktop Ready {index}", mobile=False) for index in range(6)
+    ]
+    monkeypatch.setattr(
+        queries,
+        "get_home_hero_rows",
+        lambda **_: fallback_candidates + desktop_ready,
+    )
+    monkeypatch.setattr(queries, "get_artist_genres_map", lambda _names: {})
+
+    bundle = queries.get_home_hero_bundle(7, [], [], [])
+
+    assert bundle is not None
+    assert [
+        artist["name"] for artist in bundle["hero_surfaces"]["desktop"]["artists"]
+    ] == [f"Desktop Ready {index}" for index in range(6)]
+
+
 def test_home_hero_bundle_skips_artist_without_mobile_source(monkeypatch):
     from crate.db import home_builder_discovery_queries as queries
 

--- a/app/ui/src/components/artist/ArtistArtworkGallery.test.tsx
+++ b/app/ui/src/components/artist/ArtistArtworkGallery.test.tsx
@@ -75,6 +75,37 @@ describe("ArtistArtworkGallery", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("notifies the editor when a gallery hero source is assigned", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          return Response.json({ status: "queued", task_id: "assign-hero" });
+        }
+        return Response.json({ assets: [asset] });
+      }),
+    );
+    const onHeroChanged = vi.fn();
+
+    render(
+      <ArtistArtworkGallery
+        artistId={7}
+        artistName="Converge"
+        canEdit
+        onChanged={vi.fn()}
+        onHeroChanged={onHeroChanged}
+      />,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: "Use Press photo as hero mobile",
+      }),
+    );
+
+    await waitFor(() => expect(onHeroChanged).toHaveBeenCalledWith("mobile"));
+  });
+
   it("deletes an unassigned asset after confirmation", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     let listed = true;

--- a/app/ui/src/components/artist/ArtistArtworkGallery.tsx
+++ b/app/ui/src/components/artist/ArtistArtworkGallery.tsx
@@ -15,6 +15,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { waitForTask } from "@/lib/tasks";
 
 type ArtworkSlot = "avatar" | "background" | "hero_desktop" | "hero_mobile";
+type HeroComposition = "desktop" | "mobile";
 
 export interface ArtistArtworkAsset {
   id: number;
@@ -81,11 +82,13 @@ export function ArtistArtworkGallery({
   artistName,
   canEdit,
   onChanged,
+  onHeroChanged,
 }: {
   artistId: number;
   artistName: string;
   canEdit: boolean;
   onChanged: () => void;
+  onHeroChanged?: (composition: HeroComposition) => void;
 }) {
   const uploadRef = useRef<HTMLInputElement>(null);
   const [assets, setAssets] = useState<ArtistArtworkAsset[]>([]);
@@ -170,6 +173,9 @@ export function ArtistArtworkGallery({
       await loadAssets();
       toast.success(`${slotLabel(slot)} updated`);
       onChanged();
+      if (slot === "hero_desktop" || slot === "hero_mobile") {
+        onHeroChanged?.(slot === "hero_desktop" ? "desktop" : "mobile");
+      }
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Artwork assignment failed",

--- a/app/ui/src/components/artist/ArtistArtworkSection.test.tsx
+++ b/app/ui/src/components/artist/ArtistArtworkSection.test.tsx
@@ -11,13 +11,20 @@ vi.mock("./ArtistHeroArtworkEditor", () => {
     ArtistHeroArtworkEditor: ({
       genres = [],
       onUploaded,
+      reload,
     }: {
       genres?: string[];
       onUploaded?: () => void;
+      reload?: { token: number; composition: "desktop" | "mobile" } | null;
     }) => {
       const [mountId] = useState(() => ++mountCounter);
       return (
-        <div data-testid="hero-editor-genres" data-mount-id={mountId}>
+        <div
+          data-testid="hero-editor-genres"
+          data-mount-id={mountId}
+          data-reload-token={reload?.token ?? 0}
+          data-reload-composition={reload?.composition ?? ""}
+        >
           {genres.join(",")}
           <button type="button" onClick={onUploaded}>
             Simulate hero upload
@@ -29,7 +36,25 @@ vi.mock("./ArtistHeroArtworkEditor", () => {
 });
 
 vi.mock("./ArtistArtworkGallery", () => ({
-  ArtistArtworkGallery: () => <div data-testid="artwork-gallery" />,
+  ArtistArtworkGallery: ({
+    onChanged,
+    onHeroChanged,
+  }: {
+    onChanged?: () => void;
+    onHeroChanged?: (composition: "desktop" | "mobile") => void;
+  }) => (
+    <div data-testid="artwork-gallery">
+      <button
+        type="button"
+        onClick={() => {
+          onChanged?.();
+          onHeroChanged?.("mobile");
+        }}
+      >
+        Simulate gallery mobile hero assignment
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/ImageCropUpload", () => ({
@@ -104,4 +129,30 @@ it("keeps the hero editor mounted when artwork changes", async () => {
       mountId,
     ),
   );
+});
+
+it("reloads the selected hero composition after a gallery assignment", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({ status: "ok" })),
+  );
+
+  render(<ArtistArtworkSection artistId={7} artistName="Converge" canEdit />);
+
+  await userEvent.click(
+    screen.getByRole("button", {
+      name: "Simulate gallery mobile hero assignment",
+    }),
+  );
+
+  await waitFor(() => {
+    expect(screen.getByTestId("hero-editor-genres")).toHaveAttribute(
+      "data-reload-token",
+      "1",
+    );
+    expect(screen.getByTestId("hero-editor-genres")).toHaveAttribute(
+      "data-reload-composition",
+      "mobile",
+    );
+  });
 });

--- a/app/ui/src/components/artist/ArtistArtworkSection.tsx
+++ b/app/ui/src/components/artist/ArtistArtworkSection.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/lib/library-routes";
 import { waitForTask } from "@/lib/tasks";
 
-import { ArtistHeroArtworkEditor } from "./ArtistHeroArtworkEditor";
+import {
+  ArtistHeroArtworkEditor,
+  type HeroArtworkReload,
+} from "./ArtistHeroArtworkEditor";
 import { ArtistArtworkGallery } from "./ArtistArtworkGallery";
 
 interface ArtistArtworkSectionProps {
@@ -31,6 +34,7 @@ export function ArtistArtworkSection({
   canEdit,
 }: ArtistArtworkSectionProps) {
   const [refresh, setRefresh] = useState(0);
+  const [heroReload, setHeroReload] = useState<HeroArtworkReload | null>(null);
   const [backfilling, setBackfilling] = useState(false);
   const route = { artistId, artistEntityUid, artistName };
   const version = `${imageVersion || "artwork"}-${refresh}`;
@@ -88,6 +92,12 @@ export function ArtistArtworkSection({
         artistName={artistName}
         canEdit={canEdit}
         onChanged={() => setRefresh((value) => value + 1)}
+        onHeroChanged={(composition) =>
+          setHeroReload((current) => ({
+            token: (current?.token ?? 0) + 1,
+            composition,
+          }))
+        }
       />
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -118,6 +128,11 @@ export function ArtistArtworkSection({
         artistName={artistName}
         genres={genres}
         canEdit={canEdit}
+        fallbackSourceUrl={artistBackgroundApiUrl(route, {
+          size: 1280,
+          version,
+        })}
+        reload={heroReload}
         onUploaded={() => setRefresh((value) => value + 1)}
       />
     </div>

--- a/app/ui/src/components/artist/ArtistHeroArtworkEditor.test.tsx
+++ b/app/ui/src/components/artist/ArtistHeroArtworkEditor.test.tsx
@@ -289,6 +289,90 @@ describe("ArtistHeroArtworkEditor", () => {
     });
   });
 
+  it("uses the background fallback as an editable source", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith("/hero-profile")) {
+          return new Response("not found", { status: 404 });
+        }
+        if (url.includes("/background")) {
+          return new Response("background", {
+            headers: { "Content-Type": "image/jpeg" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    render(
+      <ArtistHeroArtworkEditor artistId={7} artistName="Converge" canEdit />,
+    );
+
+    expect(await screen.findByText("Background fallback")).toBeInTheDocument();
+    expect(screen.getByTestId("canvas-source-url")).toHaveTextContent(
+      "/api/artists/7/background?size=1280",
+    );
+    expect(
+      screen.getByRole("button", { name: "Preview result" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Generate hero artwork" }),
+    ).toBeEnabled();
+  });
+
+  it("sends the background fallback file when previewing a new hero", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.mocked(waitForTask).mockResolvedValue({
+      status: "completed",
+      result: {
+        preview_url: "/api/artwork/artists/7/hero-preview/fallback-preview",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        requests.push({ url, init });
+        if (url.endsWith("/hero-profile")) {
+          return new Response("not found", { status: 404 });
+        }
+        if (url.includes("/background")) {
+          return new Response("background", {
+            headers: { "Content-Type": "image/jpeg" },
+          });
+        }
+        if (init?.method === "POST") {
+          return Response.json({
+            status: "queued",
+            task_id: "preview-fallback",
+          });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    render(
+      <ArtistHeroArtworkEditor artistId={7} artistName="Converge" canEdit />,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Preview result" }),
+    );
+
+    const previewRequest = await waitFor(() => {
+      const request = requests.find((item) =>
+        item.url.endsWith("/preview-hero"),
+      );
+      expect(request).toBeDefined();
+      return request;
+    });
+    const form = previewRequest?.init?.body as FormData;
+    expect(form.get("file")).toBeInstanceOf(File);
+    expect(form.get("composition")).toBe("desktop");
+  });
+
   it("sends the adjusted framing when generating an uploaded source", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal(

--- a/app/ui/src/components/artist/ArtistHeroArtworkEditor.tsx
+++ b/app/ui/src/components/artist/ArtistHeroArtworkEditor.tsx
@@ -13,14 +13,23 @@ import { GenrePill } from "@crate/ui/domain/genres/GenrePill";
 import { Eye, Heart, ImagePlus, Loader2, Play } from "lucide-react";
 import { toast } from "sonner";
 
-import { artistArtworkApiPath, artistHeroApiUrl } from "@/lib/library-routes";
+import {
+  artistArtworkApiPath,
+  artistBackgroundApiUrl,
+  artistHeroApiUrl,
+} from "@/lib/library-routes";
 import { waitForTask } from "@/lib/tasks";
 import type { ArtistHeroCompositionView } from "../../../../shared/web/artist-hero-contract";
 
 import { HeroCompositionCanvas } from "./HeroCompositionCanvas";
 import type { HeroRecipe } from "./hero-composition-geometry";
 
-type HeroComposition = "desktop" | "mobile";
+export type HeroComposition = "desktop" | "mobile";
+
+export interface HeroArtworkReload {
+  token: number;
+  composition: HeroComposition;
+}
 
 interface HeroProfile {
   artist_id: number;
@@ -46,6 +55,8 @@ interface ArtistHeroArtworkEditorProps {
   artistName: string;
   genres?: string[];
   canEdit: boolean;
+  fallbackSourceUrl?: string | null;
+  reload?: HeroArtworkReload | null;
   onUploaded?: () => void;
 }
 
@@ -102,6 +113,8 @@ export function ArtistHeroArtworkEditor({
   artistName,
   genres = [],
   canEdit,
+  fallbackSourceUrl,
+  reload,
   onUploaded,
 }: ArtistHeroArtworkEditorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -161,6 +174,12 @@ export function ArtistHeroArtworkEditor({
     void loadProfile();
   }, [loadProfile]);
 
+  useEffect(() => {
+    if (!reload) return;
+    setActive(reload.composition);
+    void loadProfile();
+  }, [loadProfile, reload]);
+
   const recipe = recipes[active];
   const aspect = active === "desktop" ? 1480 / 600 : 4 / 5;
   const persistedPreview = artistHeroApiUrl({ artistId }, active, {
@@ -173,7 +192,9 @@ export function ArtistHeroArtworkEditor({
         "hero-source",
       )}?composition=${active}&v=${encodeURIComponent(profile.revision)}`
     : null;
-  const activeSource = sourceUrls[active] ?? persistedSource;
+  const fallbackSource =
+    fallbackSourceUrl ?? artistBackgroundApiUrl({ artistId }, { size: 1280 });
+  const activeSource = sourceUrls[active] ?? persistedSource ?? fallbackSource;
   const previewKey = JSON.stringify({
     composition: active,
     recipe,
@@ -183,7 +204,7 @@ export function ArtistHeroArtworkEditor({
           size: sourceFiles[active]?.size,
           lastModified: sourceFiles[active]?.lastModified,
         }
-      : profile?.revision ?? null,
+      : profile?.revision ?? fallbackSource,
   });
   const canonicalPreviewView =
     previewArtifact?.key === previewKey
@@ -219,6 +240,21 @@ export function ArtistHeroArtworkEditor({
     reader.readAsDataURL(file);
   }
 
+  async function loadFallbackSourceFile() {
+    if (!fallbackSource) return null;
+    const response = await fetch(fallbackSource, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (!response.ok) throw new Error(await response.text());
+    const blob = await response.blob();
+    return new File(
+      [blob],
+      `artist-background-${active}.${blob.type.split("/")[1] || "jpg"}`,
+      { type: blob.type || "image/jpeg" },
+    );
+  }
+
   async function openPreview() {
     if (!canEdit) {
       setPreviewOpen(true);
@@ -231,7 +267,9 @@ export function ArtistHeroArtworkEditor({
       const form = new FormData();
       form.append("recipe", JSON.stringify(recipe));
       form.append("composition", active);
-      const sourceFile = sourceFiles[active];
+      const sourceFile =
+        sourceFiles[active] ??
+        (!profile ? await loadFallbackSourceFile() : null);
       if (sourceFile) form.append("file", sourceFile);
       const response = await fetch(
         artistArtworkApiPath({ artistId }, "preview-hero"),
@@ -271,7 +309,9 @@ export function ArtistHeroArtworkEditor({
     setUploading(true);
     try {
       let response: Response;
-      const sourceFile = sourceFiles[active];
+      const sourceFile =
+        sourceFiles[active] ??
+        (!profile ? await loadFallbackSourceFile() : null);
       if (sourceFile) {
         const form = new FormData();
         form.append("file", sourceFile);


### PR DESCRIPTION
## Summary

- Fix Capacitor artwork readiness so Artist Hero and Home rail images do not flicker.
- Fix Artwork editor refresh/background-fallback editing and rotate mobile heroes.
- Expose up to 8 prepared desktop heroes and start the desktop carousel on a random slide.

## Root cause

The Home builder selected only five ranked candidates before filtering for canonical desktop artwork. In production, the fifth candidate was a fallback artist, so four valid desktop heroes reached Listen.

## Validation

- Listen: 211 test files, 1794 passed, 4 skipped
- Backend Home hero tests: 27 passed
- Listen typecheck and lint passed
- Pre-commit hooks passed
