### PR TITLE
fix: stabilize mobile featured artist selection

### DIFF
--- a/app/listen/src/components/home/HomeDiscoverySections.test.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, screen, within } from "@testing-library/react";
+import { useState } from "react";
 import {
   afterEach,
   beforeAll,
@@ -125,6 +126,31 @@ function heroFixture(overrides: Partial<HomeHeroArtist> = {}): HomeHeroArtist {
     bio: "Converge are a Massachusetts hardcore band.",
     ...overrides,
   };
+}
+
+function StableMobileHeroHarness({
+  initialHeroes,
+  refreshedHeroes,
+}: {
+  initialHeroes: HomeHeroArtist[];
+  refreshedHeroes: HomeHeroArtist[];
+}) {
+  const [heroes, setHeroes] = useState(initialHeroes);
+
+  return (
+    <>
+      <HomeTasteHero
+        heroes={heroes}
+        isFollowing={() => false}
+        onOpenArtist={vi.fn()}
+        onPlay={vi.fn()}
+        onToggleFollow={vi.fn()}
+      />
+      <button type="button" onClick={() => setHeroes(refreshedHeroes)}>
+        Refresh hero data
+      </button>
+    </>
+  );
 }
 
 describe("HomeTasteHero", () => {
@@ -548,7 +574,7 @@ describe("HomeTasteHero", () => {
     });
   });
 
-  it("renders the initial artist without carousel controls on mobile", () => {
+  it("renders one selected mobile artist without carousel controls", () => {
     mockMobilePointer();
 
     renderWithListenProviders(
@@ -570,12 +596,6 @@ describe("HomeTasteHero", () => {
         onOpenArtist={vi.fn()}
         onPlay={vi.fn()}
         onToggleFollow={vi.fn()}
-        mobileIntro={
-          <div>
-            <h1>Good morning</h1>
-            <p>Saturday, August 1</p>
-          </div>
-        }
       />,
     );
 
@@ -598,11 +618,7 @@ describe("HomeTasteHero", () => {
       maskImage: "none",
     });
     expect(screen.getByTestId("mobile-hero-scrim")).toHaveClass("h-[82%]");
-    expect(screen.getByTestId("mobile-hero-intro-layout")).toHaveClass(
-      "top-0",
-      "pt-[calc(var(--listen-mobile-header-height)+0.5rem)]",
-    );
-    expect(screen.getByText("Good morning")).toBeInTheDocument();
+    expect(screen.queryByTestId("mobile-hero-intro-layout")).toBeNull();
     expect(artistHeroApiUrl).toHaveBeenCalledWith(
       expect.objectContaining({ artistEntityUid: "artist-entity" }),
       "mobile",
@@ -613,27 +629,36 @@ describe("HomeTasteHero", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("rotates through the available mobile artists", () => {
+  it("selects a mobile artist once and keeps it stable while Home remains mounted", () => {
     mockMobilePointer();
     vi.useFakeTimers();
 
     try {
+      vi.mocked(Math.random).mockReturnValue(0.99);
       renderWithListenProviders(
-        <HomeTasteHero
-          heroes={[heroFixture(), heroFixture({ id: 8, name: "Botch" })]}
-          isFollowing={() => false}
-          onOpenArtist={vi.fn()}
-          onPlay={vi.fn()}
-          onToggleFollow={vi.fn()}
+        <StableMobileHeroHarness
+          initialHeroes={[heroFixture(), heroFixture({ id: 8, name: "Botch" })]}
+          refreshedHeroes={[
+            heroFixture({ bio: "Refreshed Converge" }),
+            heroFixture({ id: 8, name: "Botch", bio: "Refreshed Botch" }),
+          ].reverse()}
         />,
       );
 
       expect(
-        screen.getByRole("heading", { name: "Converge" }),
+        screen.getByRole("heading", { name: "Botch" }),
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Refresh hero data" }),
+      );
+
+      expect(
+        screen.getByRole("heading", { name: "Botch" }),
       ).toBeInTheDocument();
 
       act(() => {
-        vi.advanceTimersByTime(8_000);
+        vi.advanceTimersByTime(24_000);
       });
 
       expect(
@@ -642,6 +667,39 @@ describe("HomeTasteHero", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("can select a different mobile artist after Home is mounted again", () => {
+    mockMobilePointer();
+
+    vi.mocked(Math.random).mockReturnValue(0);
+    const firstMount = renderWithListenProviders(
+      <HomeTasteHero
+        heroes={[heroFixture(), heroFixture({ id: 8, name: "Botch" })]}
+        isFollowing={() => false}
+        onOpenArtist={vi.fn()}
+        onPlay={vi.fn()}
+        onToggleFollow={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Converge" }),
+    ).toBeInTheDocument();
+
+    firstMount.unmount();
+    vi.mocked(Math.random).mockReturnValue(0.99);
+
+    renderWithListenProviders(
+      <HomeTasteHero
+        heroes={[heroFixture(), heroFixture({ id: 8, name: "Botch" })]}
+        isFollowing={() => false}
+        onOpenArtist={vi.fn()}
+        onPlay={vi.fn()}
+        onToggleFollow={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Botch" })).toBeInTheDocument();
   });
 
   it("does not autoplay the desktop carousel", () => {

--- a/app/listen/src/components/home/HomeDiscoverySections.tsx
+++ b/app/listen/src/components/home/HomeDiscoverySections.tsx
@@ -99,6 +99,10 @@ function dedupeHeroArtists(heroes: HomeHeroArtist[]): HomeHeroArtist[] {
   });
 }
 
+function heroSelectionKey(hero: HomeHeroArtist): string {
+  return hero.entity_uid || String(hero.id);
+}
+
 function mixArtistSummary(item: HomeGeneratedPlaylistSummary): string {
   const names = (item.artwork_artists || [])
     .map((artist) => artist.artist_name?.trim())
@@ -425,7 +429,6 @@ export function HomeTasteHero({
   onPlay,
   onToggleFollow,
   desktopIntro,
-  mobileIntro,
 }: {
   heroes: HomeHeroArtist[];
   heroSurfaces?: HomeDiscoveryHeroSurfaces | null;
@@ -434,7 +437,6 @@ export function HomeTasteHero({
   onPlay: (artist: HomeHeroArtist) => void;
   onToggleFollow: (artist: HomeHeroArtist) => void;
   desktopIntro?: ReactNode;
-  mobileIntro?: ReactNode;
 }) {
   const isDesktop = useIsDesktop();
   const composition = isDesktop ? "desktop" : "mobile";
@@ -448,7 +450,20 @@ export function HomeTasteHero({
   const [idx, setIdx] = useState(() =>
     isDesktop && count > 1 ? Math.floor(Math.random() * count) : 0,
   );
-  const activeIndex = Math.min(idx, Math.max(count - 1, 0));
+  const [mobileHeroKey, setMobileHeroKey] = useState<string | null>(() => {
+    if (isDesktop || !count) return null;
+    return heroSelectionKey(
+      surfaceHeroes[Math.floor(Math.random() * count)] || surfaceHeroes[0]!,
+    );
+  });
+  const desktopActiveIndex = Math.min(idx, Math.max(count - 1, 0));
+  const mobileHero = surfaceHeroes.find(
+    (hero) => heroSelectionKey(hero) === mobileHeroKey,
+  );
+  const mobileActiveIndex = mobileHero
+    ? Math.max(0, surfaceHeroes.indexOf(mobileHero))
+    : 0;
+  const activeIndex = isDesktop ? desktopActiveIndex : mobileActiveIndex;
   const desktopInitialIndexSet = useRef(isDesktop && count > 1);
   useHeroBackgroundPreloader(surfaceHeroes, activeIndex, composition);
 
@@ -465,24 +480,30 @@ export function HomeTasteHero({
   }, [count, isDesktop]);
 
   useEffect(() => {
-    if (isDesktop || count <= 1) return;
-    const interval = window.setInterval(() => {
-      setIdx((current) => (current + 1) % count);
-    }, 8_000);
-    return () => window.clearInterval(interval);
-  }, [count, isDesktop]);
+    if (isDesktop || !count) return;
+    setMobileHeroKey((current) => {
+      if (
+        current &&
+        surfaceHeroes.some((hero) => heroSelectionKey(hero) === current)
+      ) {
+        return current;
+      }
+      return heroSelectionKey(
+        surfaceHeroes[Math.floor(Math.random() * count)] || surfaceHeroes[0]!,
+      );
+    });
+  }, [count, isDesktop, surfaceHeroes]);
 
   if (!count) return null;
 
   if (!isDesktop) {
-    const hero = surfaceHeroes[activeIndex];
-    if (!hero) return null;
+    if (!mobileHero) return null;
+    const hero = mobileHero;
     return (
       <MobileFeaturedArtist
         hero={hero}
         backgroundSrc={heroBackgroundSrc(hero, "mobile")}
         following={isFollowing(hero.id)}
-        intro={mobileIntro}
         onOpenArtist={() => onOpenArtist(hero)}
         onPlay={() => onPlay(hero)}
         onToggleFollow={() => onToggleFollow(hero)}
@@ -502,14 +523,14 @@ export function HomeTasteHero({
       {surfaceHeroes.map((hero, index) => {
         const source = heroBackgroundSrc(hero, "desktop");
         const isPrepared =
-          index === activeIndex ||
-          index === (activeIndex + 1) % count ||
-          index === (activeIndex - 1 + count) % count;
+          index === desktopActiveIndex ||
+          index === (desktopActiveIndex + 1) % count ||
+          index === (desktopActiveIndex - 1 + count) % count;
         return (
           <DesktopFeaturedArtist
             key={hero.entity_uid || hero.id}
             hero={hero}
-            active={index === activeIndex}
+            active={index === desktopActiveIndex}
             backgroundSrc={isPrepared ? source : undefined}
             following={isFollowing(hero.id)}
             onOpenArtist={() => onOpenArtist(hero)}
@@ -522,7 +543,7 @@ export function HomeTasteHero({
       {count > 1 ? (
         <DesktopHeroNavigation
           heroes={surfaceHeroes}
-          activeIndex={activeIndex}
+          activeIndex={desktopActiveIndex}
           onPrevious={() => go(-1)}
           onNext={() => go(1)}
           onSelect={setIdx}
@@ -663,7 +684,6 @@ function MobileFeaturedArtist({
   hero,
   backgroundSrc,
   following,
-  intro,
   onOpenArtist,
   onPlay,
   onToggleFollow,
@@ -671,7 +691,6 @@ function MobileFeaturedArtist({
   hero: HomeHeroArtist;
   backgroundSrc?: string;
   following: boolean;
-  intro?: ReactNode;
   onOpenArtist: () => void;
   onPlay: () => void;
   onToggleFollow: () => void;
@@ -702,8 +721,6 @@ function MobileFeaturedArtist({
           composition="mobile"
           kicker={t("home.hero.featuredArtist")}
           artistName={hero.name}
-          intro={intro}
-          mobileIntroClassName="pt-[calc(var(--listen-mobile-header-height)+0.5rem)]"
           genres={<HeroGenres hero={hero} />}
           actions={
             <HeroActions

--- a/app/listen/src/pages/Home.test.tsx
+++ b/app/listen/src/pages/Home.test.tsx
@@ -169,6 +169,17 @@ describe("Home", () => {
     expect(screen.queryByRole("button", { name: /^DNA$/i })).toBeNull();
   });
 
+  it("does not render the greeting or date on mobile", () => {
+    renderWithListenProviders(<Home />);
+
+    expect(
+      screen.queryByRole("heading", {
+        name: /Good (morning|afternoon|evening)/,
+      }),
+    ).toBeNull();
+    expect(screen.queryByTestId("mobile-hero-intro-layout")).toBeNull();
+  });
+
   it("does not show an infinite loader when discovery fails", () => {
     vi.mocked(useApi).mockReturnValue({
       data: null,

--- a/app/listen/src/pages/Home.tsx
+++ b/app/listen/src/pages/Home.tsx
@@ -589,7 +589,6 @@ export function Home() {
         onPlay={(artist) => void playHeroArtist(artist)}
         onToggleFollow={(artist) => void toggleHeroFollow(artist)}
         desktopIntro={isDesktop ? homeIntro : undefined}
-        mobileIntro={!isDesktop ? homeIntro : undefined}
       />
 
       <div


### PR DESCRIPTION
## Summary

- Remove mobile hero autoplay/loop so the featured artist stays fixed while Home remains mounted.
- Select a new mobile artist when Home is entered again, preserving the selection by artist identity across refreshed or reordered snapshots.
- Keep the canonical hero path without legacy fallback and remove the mobile greeting/date.

## Root cause

The mobile hero used a timed index rotation, so every interval changed the artist and recreated the visible artwork. Refreshes could also change the selected artist when the backend reordered candidates.

## Validation

- Targeted Vitest: 40 tests passed.
- TypeScript typecheck passed.
- ESLint passed.
- Prettier and diff checks passed.
