### PR TITLE
fix: rotate Artist Hero candidates

### DIFF
--- a/app/crate/db/home_builder_discovery_queries.py
+++ b/app/crate/db/home_builder_discovery_queries.py
@@ -13,6 +13,7 @@ from crate.db.home_builder_shared import _trim_bio
 from crate.db.home_hero_scoring import (
     HOME_HERO_SCORE_VERSION,
     score_home_hero_rows,
+    select_home_hero_rows,
     strip_home_hero_score,
 )
 from crate.db.home_debug import record_home_hero_debug
@@ -27,7 +28,7 @@ from crate.genre_taxonomy import expand_genre_terms_with_aliases
 from crate.utils import coerce_int
 
 HOME_JUST_LANDED_VERSION = "home_just_landed_v2"
-HOME_HERO_CANDIDATE_LIMIT = 15
+HOME_HERO_CANDIDATE_LIMIT = 32
 HOME_HERO_SELECTED_LIMIT = 8
 _CANONICAL_SURFACES = ("desktop", "mobile")
 
@@ -130,7 +131,7 @@ def _rank_home_hero_rows(
     followed_names_lower: list[str],
     similar_target_names_lower: list[str],
     top_genres_lower: list[str],
-) -> tuple[list[dict], dict[str, set[str]]] | None:
+) -> tuple[list[dict], dict[str, list[dict]]] | None:
     rows = get_home_hero_rows(
         user_id=user_id,
         followed_names_lower=followed_names_lower,
@@ -183,16 +184,25 @@ def _rank_home_hero_rows(
         }
     )
 
-    artist_names = [row["name"] for row in selected_rows]
+    surface_rows = {
+        composition: select_home_hero_rows(
+            [row for row in ranked_rows if _canonical_surface_ready(row, composition)],
+            user_id=user_id,
+            limit=HOME_HERO_SELECTED_LIMIT,
+        )
+        for composition in _CANONICAL_SURFACES
+    }
+    source_rows = list(selected_rows)
+    for rows_for_surface in surface_rows.values():
+        source_rows.extend(rows_for_surface)
+    source_rows = _dedupe_home_hero_rows(source_rows)
+
+    artist_names = [row["name"] for row in source_rows]
     genre_map = get_artist_genres_map(artist_names)
 
-    public_rows: list[dict] = []
-    ready_by_surface = {composition: set() for composition in _CANONICAL_SURFACES}
-    for source_item in selected_rows:
+    public_by_name: dict[str, dict] = {}
+    for source_item in source_rows:
         item = dict(source_item)
-        for composition in _CANONICAL_SURFACES:
-            if _canonical_surface_ready(source_item, composition):
-                ready_by_surface[composition].add(str(source_item["name"]))
         _add_hero_artwork_bounds(item)
         item["bio"] = _trim_bio(item.get("bio") or "")
         item["genres"] = genre_map.get(item["name"], [])[:4]
@@ -202,9 +212,14 @@ def _rank_home_hero_rows(
             "_hero_review_status",
         ):
             item.pop(key, None)
-        public_rows.append(strip_home_hero_score(item))
+        public_by_name[str(source_item["name"])] = strip_home_hero_score(item)
 
-    return public_rows, ready_by_surface
+    hero = [public_by_name[str(row["name"])] for row in selected_rows]
+    public_surfaces = {
+        composition: [public_by_name[str(row["name"])] for row in rows_for_surface]
+        for composition, rows_for_surface in surface_rows.items()
+    }
+    return hero, public_surfaces
 
 
 def get_home_hero_bundle(
@@ -222,13 +237,12 @@ def get_home_hero_bundle(
     if ranked is None:
         return None
 
-    hero, ready_by_surface = ranked
+    hero, surface_artists = ranked
     surfaces = {}
     for composition in _CANONICAL_SURFACES:
-        ready_names = ready_by_surface[composition]
         surfaces[composition] = {
             "mode": "canonical",
-            "artists": [item for item in hero if item["name"] in ready_names],
+            "artists": surface_artists[composition],
         }
 
     return {"hero": hero, "hero_surfaces": surfaces}

--- a/app/crate/db/home_hero_scoring.py
+++ b/app/crate/db/home_hero_scoring.py
@@ -7,6 +7,7 @@ from typing import Any
 
 HOME_HERO_SCORE_VERSION = "home_hero_v2"
 HOME_HERO_ROTATION_VERSION = "home_hero_rotation_v1"
+HOME_HERO_SELECTION_VERSION = "home_hero_selection_v1"
 
 HOME_HERO_SCORE_WEIGHTS_V1 = {
     "followed_artist": 2.6,
@@ -208,11 +209,56 @@ def rotate_home_hero_rows(
     return [selected, *remaining, *rows[candidate_count:]]
 
 
+def select_home_hero_rows(
+    rows: list[dict],
+    *,
+    user_id: int,
+    day: date | None = None,
+    limit: int = 8,
+) -> list[dict]:
+    """Select a stable daily subset from the complete ranked candidate pool.
+
+    Ranking still controls the weights, but the selection is made without
+    replacement so artists outside the first eight can become visible on a
+    later day. The result remains deterministic for a user and UTC day.
+    """
+
+    if limit <= 0 or not rows:
+        return []
+    if len(rows) <= limit:
+        return list(rows)
+
+    selection_day = day or datetime.now(timezone.utc).date()
+    remaining = list(rows)
+    selected: list[dict] = []
+    selection_count = min(limit, len(remaining))
+
+    for selection_index in range(selection_count):
+        weights = [
+            0.35 + (1.0 / ((index + 1) ** 0.65)) for index in range(len(remaining))
+        ]
+        target = _stable_unit_interval(
+            f"{HOME_HERO_SELECTION_VERSION}:{user_id}:"
+            f"{selection_day.isoformat()}:{selection_index}"
+        ) * sum(weights)
+        selected_index = len(remaining) - 1
+        for index, weight in enumerate(weights):
+            if target < weight:
+                selected_index = index
+                break
+            target -= weight
+        selected.append(remaining.pop(selected_index))
+
+    return selected
+
+
 __all__ = [
     "HOME_HERO_SCORE_VERSION",
     "HOME_HERO_ROTATION_VERSION",
+    "HOME_HERO_SELECTION_VERSION",
     "HOME_HERO_SCORE_WEIGHTS_V1",
     "rotate_home_hero_rows",
+    "select_home_hero_rows",
     "score_home_hero_rows",
     "strip_home_hero_score",
 ]

--- a/app/tests/test_home_hero_scoring.py
+++ b/app/tests/test_home_hero_scoring.py
@@ -115,6 +115,33 @@ def test_home_hero_rotation_is_stable_per_day_but_varies_over_time():
     assert len(across_days) >= 2
 
 
+def test_home_hero_selection_rotates_the_full_candidate_pool():
+    from crate.db.home_hero_scoring import select_home_hero_rows
+
+    rows = [{"id": index, "name": f"Artist {index}"} for index in range(24)]
+    first_day = date(2026, 8, 2)
+
+    same_day = select_home_hero_rows(rows, user_id=7, day=first_day, limit=8)
+    repeated_same_day = select_home_hero_rows(rows, user_id=7, day=first_day, limit=8)
+    across_days = {
+        tuple(
+            row["id"]
+            for row in select_home_hero_rows(
+                rows,
+                user_id=7,
+                day=first_day + timedelta(days=offset),
+                limit=8,
+            )
+        )
+        for offset in range(31)
+    }
+
+    assert same_day == repeated_same_day
+    assert len(same_day) == 8
+    assert len({row["id"] for row in same_day}) == 8
+    assert len(across_days) >= 2
+
+
 def test_home_hero_builder_preserves_recent_arrival_order(monkeypatch):
     from crate.db import home_builder_discovery_queries as queries
 
@@ -176,7 +203,7 @@ def test_home_hero_builder_personalizes_a_larger_candidate_pool(monkeypatch):
 
     heroes = queries.get_home_hero(7, ["followed match"], [], ["hardcore"])
 
-    assert captured["limit"] == 15
+    assert captured["limit"] == 32
     assert heroes is not None
     assert heroes[0]["name"] == "Followed Match"
     assert len(heroes) == 2


### PR DESCRIPTION
## Summary
- expand the Artist Hero candidate pool from 15 to 32 artists
- select each canonical desktop/mobile surface from the full ranked pool without replacement
- keep the visible carousel capped at 8 artists while rotating deterministically by user and UTC day
- preserve the legacy fallback hero selection and add regression coverage

## Validation
- `make dev-test-backend`: static checks passed; full pytest run was interrupted by the ephemeral Postgres test container shutting down, causing fixture connection errors
- `uv run pyright`: passed
- `uv run ruff check app/crate app/tests`: passed
- `uv run ruff format --check app/crate app/tests`: passed
- `./.venv/bin/python -m pytest -q app/tests/test_home_hero_scoring.py app/tests/test_home_projection_policy.py`: 21 passed
