### PR TITLE
ci: enable DeepSeek PR reviews

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,30 @@
+name: PR Agent Review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    name: Review pull request
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      (github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/review')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Run PR-Agent
+        uses: docker://pragent/pr-agent:0.41.0-github_action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEEPSEEK.KEY: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,95 @@
+[config]
+model = "deepseek/deepseek-v4-pro"
+fallback_models = ["deepseek/deepseek-v4-flash"]
+ai_timeout = 300
+large_patch_policy = "clip"
+max_model_tokens = 32000
+restricted_mode = true
+
+[pr_reviewer]
+num_max_findings = 8
+persistent_comment = true
+require_tests_review = true
+require_security_review = true
+require_can_be_split_review = true
+require_score_review = false
+
+extra_instructions = """
+You are the code review agent for the Crate repository. Respond in Spanish, keep
+technical names, identifiers and code references unchanged, and review the
+actual PR diff rather than producing a generic checklist.
+
+Review policy:
+- Report only actionable issues introduced or worsened by this PR.
+- Do not report pre-existing debt unless the PR touches it or makes it worse.
+- Prioritize correctness, regressions, security, data loss, concurrency,
+  performance and maintainability over stylistic preferences.
+- Do not request speculative abstractions or unrelated refactors.
+- Do not approve, merge or modify the PR automatically.
+- Classify findings as P0/P1/P2/P3, where P0/P1 are release-blocking or high
+  impact, P2 is important but non-blocking, and P3 is a minor actionable issue.
+- For every finding include the file and line, concrete evidence, impact, and
+  a concise suggested fix.
+
+Repository architecture:
+- The backend is Python 3.13 with FastAPI, SQLAlchemy 2.0, Alembic and
+  Dramatiq.
+- /music is mounted read-only for the API. Filesystem writes must happen in
+  workers, never in API endpoints.
+- Complex SQL belongs in app/crate/db/queries or app/crate/db/jobs. New
+  internal imports should use concrete db modules instead of the compatibility
+  facade app/crate/db/__init__.py.
+- New background work belongs in Dramatiq actors and worker handlers, not in
+  the deprecated orchestrator.
+- The frontend uses React 19, Vite, Tailwind CSS 4 and the @crate/ui npm
+  workspace. Use the existing useApi, api and encPath conventions.
+- Shared UI components belong in @crate/ui only when both app/ui and
+  app/listen use them. Keep the admin and Listen applications separate.
+- Nivo is preferred for new charts; do not introduce new recharts usage.
+- Every changed behavior needs appropriate tests. Check test coverage for
+  changed public functions and components, including edge cases and failure
+  paths.
+
+Frontend and design-system review:
+- Flag hardcoded colors (hex, rgb/rgba, hsl), arbitrary utility values,
+  unnecessary inline styles and duplicated visual constants when semantic
+  tokens or CSS variables should be used.
+- Check that theme and skin remain orthogonal. Skins may change visual identity
+  tokens such as palette, surfaces, radii, shadows, brand typography and
+  decorative effects, but must not change layout or behavior.
+- The default theme/skin must preserve the current Listen identity with
+  perceptual parity, not accidental duplicated values.
+- Prefer CSS variables plus semantic Tailwind utilities. Inline styles are
+  acceptable only for justified calculated values or explicitly allowlisted
+  dynamic cases.
+- Check the component layering: primitives, composites, domain, feature and
+  pages. Flag components with too many responsibilities, boolean-prop
+  proliferation, unclear contracts or duplicated implementations.
+- Check accessibility, keyboard interaction, focus states, reduced motion,
+  responsive behavior, loading/error/empty states and semantic HTML.
+- Check React effects, subscriptions, event listeners, timers, requestAnimation
+  frames, visibility handling, stale closures, unnecessary rerenders and
+  unstable list keys.
+- Flag unjustified any, non-null assertions, suppressions and unsafe casts.
+
+Backend review:
+- Check read/write separation, transaction scope usage, authorization,
+  validation, idempotency, queue selection, retries, timeouts and error
+  handling.
+- Check SQL parameters, migration safety, indexes, N+1 queries and behavior
+  under empty, duplicate, stale or concurrent data.
+- Ensure API schemas and response contracts are consistent with existing routes.
+
+Review output:
+- Separate blocking correctness/security findings from non-blocking quality
+  findings.
+- Do not repeat the same issue across files; group equivalent findings.
+- If no actionable issue is found, say so and still mention any missing or
+  insufficient tests that materially reduce confidence.
+"""
+
+[github_action_config]
+auto_review = true
+auto_describe = false
+auto_improve = false
+pr_actions = ["opened", "reopened", "ready_for_review", "synchronize"]


### PR DESCRIPTION
## Summary

- add the DeepSeek-backed PR-Agent workflow
- configure repository-specific review guidance for Crate
- use the existing `DEEPSEEK_API_KEY` repository secret

## Validation

- branch is based directly on `main`
- workflow and configuration are the only changed files

After this PR is merged, the design-system PR can be opened from a branch that no longer needs to carry the review automation changes.