### PR TITLE
fix: reduce catalog and lyrics status worker pressure

### DIFF
--- a/app/crate/db/jobs/global_catalog_reconciliation.py
+++ b/app/crate/db/jobs/global_catalog_reconciliation.py
@@ -44,6 +44,7 @@ from crate.slugs import build_artist_slug, build_public_album_slug
 
 _GLOBAL_UID_NAMESPACE = uuid.UUID("e43655c7-8af2-4c5a-92f6-a5126dff7f84")
 _RECONCILIATION_ENTITY_TYPES = ("artist", "album", "track")
+_DEPENDENCY_RETRY_SECONDS = 3600
 log = logging.getLogger(__name__)
 
 
@@ -216,6 +217,11 @@ def reconcile_dirty_catalog_sources(*, limit: int = 500) -> dict[str, int]:
                     str(exc),
                     requested_at=dirty["requested_at"],
                     claimed_at=dirty["claimed_at"],
+                    retry_after_seconds=(
+                        _DEPENDENCY_RETRY_SECONDS
+                        if "waiting for its canonical artist" in str(exc)
+                        else None
+                    ),
                     session=session,
                 )
             failed += 1

--- a/app/crate/db/migrations/versions/090_dirty_source_retry_backoff.py
+++ b/app/crate/db/migrations/versions/090_dirty_source_retry_backoff.py
@@ -1,0 +1,35 @@
+"""Back off dirty sources waiting for canonical dependencies."""
+
+from alembic import op
+
+
+revision = "090"
+down_revision = "089"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE global_catalog_dirty_sources
+        ADD COLUMN IF NOT EXISTS next_attempt_at TIMESTAMPTZ
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_global_catalog_dirty_sources_retry
+        ON global_catalog_dirty_sources (next_attempt_at, requested_at, id)
+        WHERE completed_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_global_catalog_dirty_sources_retry")
+    op.execute(
+        """
+        ALTER TABLE global_catalog_dirty_sources
+        DROP COLUMN IF EXISTS next_attempt_at
+        """
+    )

--- a/app/crate/db/repositories/global_catalog_dirty_sources.py
+++ b/app/crate/db/repositories/global_catalog_dirty_sources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 from sqlalchemy import text
@@ -115,11 +116,8 @@ def _enqueue_dirty_source(
                     THEN NULL
                     ELSE global_catalog_dirty_sources.completed_at
                 END,
-                last_error = CASE
-                    WHEN global_catalog_dirty_sources.completed_at IS NOT NULL
-                    THEN NULL
-                    ELSE global_catalog_dirty_sources.last_error
-                END
+                last_error = NULL,
+                next_attempt_at = NULL
             """
         ),
         {
@@ -157,6 +155,10 @@ def claim_dirty_sources(
                     FROM global_catalog_dirty_sources
                     WHERE completed_at IS NULL
                       AND (
+                        next_attempt_at IS NULL
+                        OR next_attempt_at <= NOW()
+                      )
+                      AND (
                         claimed_at IS NULL
                         OR claimed_at < NOW() - make_interval(secs => :lease_seconds)
                       )
@@ -184,7 +186,8 @@ def claim_dirty_sources(
                     dirty.claimed_at,
                     dirty.completed_at,
                     dirty.attempts,
-                    dirty.last_error
+                    dirty.last_error,
+                    dirty.next_attempt_at
                 """
             ),
             {"limit": capped, "lease_seconds": capped_lease},
@@ -212,6 +215,7 @@ def complete_dirty_source(
                     ELSE NULL
                 END,
                 claimed_at = NULL,
+                next_attempt_at = NULL,
                 last_error = CASE
                     WHEN requested_at = :requested_at THEN NULL
                     ELSE last_error
@@ -235,14 +239,24 @@ def fail_dirty_source(
     *,
     requested_at,
     claimed_at,
+    retry_after_seconds: int | None = None,
     session,
 ) -> bool:
+    next_attempt_at = None
+    if retry_after_seconds is not None:
+        next_attempt_at = datetime.now(timezone.utc) + timedelta(
+            seconds=max(1, int(retry_after_seconds))
+        )
     result = session.execute(
         text(
             """
             UPDATE global_catalog_dirty_sources
             SET
                 claimed_at = NULL,
+                next_attempt_at = CASE
+                    WHEN requested_at = :requested_at THEN :next_attempt_at
+                    ELSE next_attempt_at
+                END,
                 last_error = CASE
                     WHEN requested_at = :requested_at THEN :error
                     ELSE last_error
@@ -256,6 +270,7 @@ def fail_dirty_source(
             "error": error[:4000],
             "requested_at": requested_at,
             "claimed_at": claimed_at,
+            "next_attempt_at": next_attempt_at,
         },
     )
     return int(getattr(result, "rowcount", 0) or 0) == 1

--- a/app/crate/db/repositories/portable_metadata.py
+++ b/app/crate/db/repositories/portable_metadata.py
@@ -133,6 +133,13 @@ def mark_album_rich_export(
 
 
 def get_portable_metadata_status() -> dict[str, int]:
+    from crate.db.cache_store import get_cache, set_cache
+
+    cache_key = "analysis:portable_metadata_status:v2"
+    cached = get_cache(cache_key, max_age_seconds=60)
+    if isinstance(cached, dict):
+        return {key: int(value or 0) for key, value in cached.items()}
+
     with read_scope() as session:
         row = (
             session.execute(
@@ -143,55 +150,49 @@ def get_portable_metadata_status() -> dict[str, int]:
                         (SELECT COUNT(*) FROM library_tracks) AS total_tracks,
                         (SELECT COUNT(*) FROM library_albums) AS total_albums
                 ),
+                track_keys AS MATERIALIZED (
+                    SELECT
+                        id,
+                        lower(regexp_replace(trim(artist), '\\s+', ' ', 'g')) AS artist_key,
+                        lower(regexp_replace(
+                            trim(COALESCE(NULLIF(title, ''), filename)),
+                            '\\s+',
+                            ' ',
+                            'g'
+                        )) AS title_key
+                    FROM library_tracks
+                ),
+                matched AS (
+                    SELECT
+                        tk.id,
+                        l.found IS TRUE
+                            AND (l.synced_lyrics IS NOT NULL OR l.plain_lyrics IS NOT NULL)
+                            AS has_content
+                    FROM track_keys tk
+                    JOIN track_lyrics l
+                      ON l.provider = 'lrclib'
+                     AND l.track_id = tk.id
+                    UNION ALL
+                    SELECT
+                        tk.id,
+                        l.found IS TRUE
+                            AND (l.synced_lyrics IS NOT NULL OR l.plain_lyrics IS NOT NULL)
+                            AS has_content
+                    FROM track_keys tk
+                    JOIN track_lyrics l
+                      ON l.provider = 'lrclib'
+                     AND l.track_id IS NULL
+                     AND l.artist_key = tk.artist_key
+                     AND l.title_key = tk.title_key
+                ),
                 lyrics AS (
                     SELECT
-                        COUNT(*) FILTER (WHERE cached) AS lyrics_cached,
-                        COUNT(*) FILTER (WHERE found) AS lyrics_found
+                        COUNT(*) AS lyrics_cached,
+                        COUNT(*) FILTER (WHERE has_content) AS lyrics_found
                     FROM (
-                        SELECT
-                            EXISTS (
-                                SELECT 1
-                                FROM track_lyrics l
-                                WHERE l.provider = 'lrclib'
-                                  AND (
-                                      l.track_id = lt.id
-                                      OR (
-                                          l.track_id IS NULL
-                                          AND l.artist_key = lower(regexp_replace(trim(lt.artist), '\\s+', ' ', 'g'))
-                                          AND l.title_key = lower(
-                                              regexp_replace(
-                                                  trim(COALESCE(NULLIF(lt.title, ''), lt.filename)),
-                                                  '\\s+',
-                                                  ' ',
-                                                  'g'
-                                              )
-                                          )
-                                      )
-                                  )
-                            ) AS cached,
-                            EXISTS (
-                                SELECT 1
-                                FROM track_lyrics l
-                                WHERE l.provider = 'lrclib'
-                                  AND l.found IS TRUE
-                                  AND (l.synced_lyrics IS NOT NULL OR l.plain_lyrics IS NOT NULL)
-                                  AND (
-                                      l.track_id = lt.id
-                                      OR (
-                                          l.track_id IS NULL
-                                          AND l.artist_key = lower(regexp_replace(trim(lt.artist), '\\s+', ' ', 'g'))
-                                          AND l.title_key = lower(
-                                              regexp_replace(
-                                                  trim(COALESCE(NULLIF(lt.title, ''), lt.filename)),
-                                                  '\\s+',
-                                                  ' ',
-                                                  'g'
-                                              )
-                                          )
-                                      )
-                                  )
-                            ) AS found
-                        FROM library_tracks lt
+                        SELECT id, bool_or(has_content) AS has_content
+                        FROM matched
+                        GROUP BY id
                     ) per_track
                 ),
                 portable AS (
@@ -224,7 +225,9 @@ def get_portable_metadata_status() -> dict[str, int]:
             .first()
         )
 
-    return {key: int(value or 0) for key, value in dict(row or {}).items()}
+    result = {key: int(value or 0) for key, value in dict(row or {}).items()}
+    set_cache(cache_key, result, ttl=60)
+    return result
 
 
 def _formats(value: Any) -> list[str]:

--- a/app/tests/test_federation_migration_matrix.py
+++ b/app/tests/test_federation_migration_matrix.py
@@ -306,7 +306,7 @@ def _seed_063_legacy_state() -> dict[str, str]:
 
 
 def _assert_hardened_state(ids: dict[str, str]) -> None:
-    assert _scalar("SELECT version_num FROM alembic_version") == "089"
+    assert _scalar("SELECT version_num FROM alembic_version") == "090"
     assert (
         _scalar(
             "SELECT status FROM federation_local_keys WHERE node_uid = %s",
@@ -356,7 +356,7 @@ def test_empty_database_migrates_from_base_to_head(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "089"
+    assert _scalar("SELECT version_num FROM alembic_version") == "090"
     for table in (
         "federation_local_keys",
         "federation_catalog_changes",
@@ -385,7 +385,7 @@ def test_080_upgrade_removes_deprecated_navidrome_column(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "089"
+    assert _scalar("SELECT version_num FROM alembic_version") == "090"
     assert (
         _scalar(
             """
@@ -426,7 +426,7 @@ def test_real_main_049_snapshot_upgrades_without_user_data_loss(pg_db):
 
     _migrate("head")
 
-    assert _scalar("SELECT version_num FROM alembic_version") == "089"
+    assert _scalar("SELECT version_num FROM alembic_version") == "090"
     assert _scalar("SELECT email FROM users WHERE id = %s", (ids["user_id"],)) == (
         "legacy@example.test"
     )

--- a/app/tests/test_global_catalog_dirty_sources.py
+++ b/app/tests/test_global_catalog_dirty_sources.py
@@ -83,6 +83,40 @@ def test_claimed_dirty_source_is_not_claimed_twice_and_failure_keeps_error(pg_db
     assert retried[0]["last_error"] == "peer manifest unavailable"
 
 
+def test_dependency_failure_is_deferred_until_retry_time_and_reopened_by_update(pg_db):
+    from crate.db.repositories.global_catalog_dirty_sources import (
+        claim_dirty_sources,
+        enqueue_local_dirty_source,
+        fail_dirty_source,
+    )
+    from crate.db.tx import transaction_scope
+
+    entity_uid = "e3f3c2f2-2bb3-4be7-8a5c-53d3b4c40f1d"
+    with transaction_scope() as session:
+        enqueue_local_dirty_source("track", entity_uid, "upsert", session=session)
+
+    with transaction_scope() as session:
+        claimed = claim_dirty_sources(1, session=session)[0]
+        fail_dirty_source(
+            int(claimed["id"]),
+            "Track source is waiting for its canonical artist",
+            requested_at=claimed["requested_at"],
+            claimed_at=claimed["claimed_at"],
+            retry_after_seconds=3600,
+            session=session,
+        )
+
+    with transaction_scope() as session:
+        assert claim_dirty_sources(1, session=session) == []
+        enqueue_local_dirty_source("track", entity_uid, "upsert", session=session)
+
+    with transaction_scope() as session:
+        reopened = claim_dirty_sources(1, session=session)
+
+    assert len(reopened) == 1
+    assert reopened[0]["last_error"] is None
+
+
 def test_mutation_arriving_during_claim_is_not_completed_by_stale_worker(pg_db):
     from crate.db.repositories.global_catalog_dirty_sources import (
         claim_dirty_sources,

--- a/app/tests/test_node_first_catalog_migration.py
+++ b/app/tests/test_node_first_catalog_migration.py
@@ -29,3 +29,19 @@ def test_node_first_catalog_state_upgrade_creates_state_and_claim_index(monkeypa
     assert "INSERT INTO global_catalog_state" in sql
     assert "global_catalog_dirty_sources_local_ref_check" in sql
     assert "global_catalog_dirty_sources_federated_ref_check" in sql
+
+
+def test_dirty_source_retry_backoff_migration_adds_retry_column_and_index(monkeypatch):
+    migration = importlib.import_module(
+        "crate.db.migrations.versions.090_dirty_source_retry_backoff"
+    )
+    statements: list[str] = []
+    monkeypatch.setattr(migration.op, "execute", statements.append)
+
+    migration.upgrade()
+
+    sql = "\n".join(statements)
+    assert migration.revision == "090"
+    assert migration.down_revision == "089"
+    assert "next_attempt_at TIMESTAMPTZ" in sql
+    assert "idx_global_catalog_dirty_sources_retry" in sql

--- a/app/tests/test_portable_metadata_status.py
+++ b/app/tests/test_portable_metadata_status.py
@@ -1,0 +1,81 @@
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import PG_AVAILABLE
+
+
+pytestmark = pytest.mark.skipif(not PG_AVAILABLE, reason="PostgreSQL not available")
+
+
+def test_portable_metadata_status_counts_track_and_fallback_lyrics(pg_db):
+    from crate.db.cache_store import delete_cache
+    from crate.db.repositories.portable_metadata import get_portable_metadata_status
+    from crate.db.tx import transaction_scope
+
+    cache_key = "analysis:portable_metadata_status:v2"
+    delete_cache(cache_key)
+    before = get_portable_metadata_status()
+
+    pg_db.upsert_artist({"name": "Portable Status Artist"})
+    album_id = pg_db.upsert_album(
+        {
+            "artist": "Portable Status Artist",
+            "name": "Portable Status Album",
+            "path": "/music/Portable Status Artist/Portable Status Album",
+            "track_count": 3,
+        }
+    )
+    for number in range(1, 4):
+        pg_db.upsert_track(
+            {
+                "album_id": album_id,
+                "artist": "Portable Status Artist",
+                "album": "Portable Status Album",
+                "filename": f"0{number} track.flac",
+                "title": f"Track {number}",
+                "path": f"/music/Portable Status Artist/Portable Status Album/0{number} track.flac",
+                "duration": 180.0,
+                "size": 1000,
+                "format": "flac",
+            }
+        )
+
+    with transaction_scope() as session:
+        tracks = (
+            session.execute(
+                text(
+                    """
+                SELECT id, title
+                FROM library_tracks
+                WHERE album_id = :album_id
+                ORDER BY id
+                """
+                ),
+                {"album_id": album_id},
+            )
+            .mappings()
+            .all()
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO track_lyrics
+                    (provider, artist_key, title_key, artist, title, track_id, found, plain_lyrics)
+                VALUES
+                    ('lrclib', 'portable status artist', 'track 1', 'Portable Status Artist', 'Track 1', :track_id, TRUE, 'lyrics'),
+                    ('lrclib', 'portable status artist', 'track 2', 'Portable Status Artist', 'Track 2', NULL, TRUE, 'lyrics'),
+                    ('lrclib', 'portable status artist', 'track 3', 'Portable Status Artist', 'Track 3', :missing_track_id, FALSE, NULL)
+                """
+            ),
+            {
+                "track_id": tracks[0]["id"],
+                "missing_track_id": tracks[2]["id"],
+            },
+        )
+
+    delete_cache(cache_key)
+    after = get_portable_metadata_status()
+
+    assert after["lyrics_cached"] - before["lyrics_cached"] == 3
+    assert after["lyrics_found"] - before["lyrics_found"] == 2
+    assert after["lyrics_missing"] - before["lyrics_missing"] == 1

--- a/app/tests/test_postgres_test_database.py
+++ b/app/tests/test_postgres_test_database.py
@@ -32,7 +32,7 @@ def test_pg_db_uses_an_isolated_clone_of_the_initialized_template(pg_db) -> None
 
     assert database_name != TEST_DB_NAME
     assert database_name.startswith(f"{TEST_DB_NAME}_case_")
-    assert revision == "089"
+    assert revision == "090"
     assert admin_count >= 1
     assert os.environ["CRATE_POSTGRES_DB"] == database_name
 


### PR DESCRIPTION
## Summary
- Optimize and cache the portable metadata lyrics status query.
- Defer global catalog sources waiting for canonical artists for one hour, while reopening them immediately when updated.
- Add migration 090 and regression coverage.

## Validation
- 48 relevant pytest tests passed.
- Ruff and pre-commit hooks passed.

This hotfix is intentionally isolated from the pending React Doctor worktree changes.