### PR TITLE
fix: reconcile stale playback variants and stats snapshots

### DIFF
--- a/app/crate/api/schemas/media.py
+++ b/app/crate/api/schemas/media.py
@@ -347,6 +347,9 @@ class PlaybackDeliveryStatsResponse(BaseModel):
     variant_tracks: int = 0
     ready: int = 0
     pending: int = 0
+    pending_active: int = 0
+    pending_unassigned: int = 0
+    pending_stale: int = 0
     running: int = 0
     failed: int = 0
     missing: int = 0

--- a/app/crate/db/queries/streaming_admin.py
+++ b/app/crate/db/queries/streaming_admin.py
@@ -29,16 +29,32 @@ def get_playback_delivery_snapshot(*, limit: int = 20) -> dict:
                 SELECT
                     COUNT(*) AS variants,
                     COUNT(DISTINCT sv.track_id) FILTER (WHERE sv.track_id IS NOT NULL) AS variant_tracks,
-                    COUNT(*) FILTER (WHERE status = 'ready') AS ready,
-                    COUNT(*) FILTER (WHERE status = 'pending') AS pending,
-                    COUNT(*) FILTER (WHERE status = 'running') AS running,
-                    COUNT(*) FILTER (WHERE status = 'failed') AS failed,
-                    COUNT(*) FILTER (WHERE status = 'missing') AS missing,
-                    COUNT(DISTINCT sv.track_id) FILTER (WHERE status = 'ready' AND sv.track_id IS NOT NULL) AS ready_tracks,
-                    COALESCE(SUM(bytes) FILTER (WHERE status = 'ready'), 0) AS cached_bytes,
-                    COALESCE(SUM(source_size) FILTER (WHERE status = 'ready'), 0) AS ready_source_bytes,
-                    AVG(EXTRACT(EPOCH FROM (completed_at - created_at))) FILTER (WHERE status = 'ready' AND completed_at IS NOT NULL) AS avg_prepare_seconds
+                    COUNT(*) FILTER (WHERE sv.status = 'ready') AS ready,
+                    COUNT(*) FILTER (WHERE sv.status = 'pending') AS pending,
+                    COUNT(*) FILTER (
+                        WHERE sv.status = 'pending'
+                          AND t.status IN ('pending', 'running', 'delegated', 'completing')
+                    ) AS pending_active,
+                    COUNT(*) FILTER (
+                        WHERE sv.status = 'pending' AND sv.task_id IS NULL
+                    ) AS pending_unassigned,
+                    COUNT(*) FILTER (
+                        WHERE sv.status = 'pending'
+                          AND sv.task_id IS NOT NULL
+                          AND (
+                              t.id IS NULL
+                              OR t.status NOT IN ('pending', 'running', 'delegated', 'completing')
+                          )
+                    ) AS pending_stale,
+                    COUNT(*) FILTER (WHERE sv.status = 'running') AS running,
+                    COUNT(*) FILTER (WHERE sv.status = 'failed') AS failed,
+                    COUNT(*) FILTER (WHERE sv.status = 'missing') AS missing,
+                    COUNT(DISTINCT sv.track_id) FILTER (WHERE sv.status = 'ready' AND sv.track_id IS NOT NULL) AS ready_tracks,
+                    COALESCE(SUM(sv.bytes) FILTER (WHERE sv.status = 'ready'), 0) AS cached_bytes,
+                    COALESCE(SUM(sv.source_size) FILTER (WHERE sv.status = 'ready'), 0) AS ready_source_bytes,
+                    AVG(EXTRACT(EPOCH FROM (sv.completed_at - sv.created_at))) FILTER (WHERE sv.status = 'ready' AND sv.completed_at IS NOT NULL) AS avg_prepare_seconds
                 FROM stream_variants sv
+                LEFT JOIN tasks t ON t.id = sv.task_id
                 JOIN library_tracks lt
                   ON lt.id = sv.track_id
                  AND lt.path = sv.source_path
@@ -134,6 +150,9 @@ def get_playback_delivery_snapshot(*, limit: int = 20) -> dict:
             "variant_tracks": _int(variant_stats.get("variant_tracks")),
             "ready": _int(variant_stats.get("ready")),
             "pending": _int(variant_stats.get("pending")),
+            "pending_active": _int(variant_stats.get("pending_active")),
+            "pending_unassigned": _int(variant_stats.get("pending_unassigned")),
+            "pending_stale": _int(variant_stats.get("pending_stale")),
             "running": _int(variant_stats.get("running")),
             "failed": _int(variant_stats.get("failed")),
             "missing": _int(variant_stats.get("missing")),

--- a/app/crate/db/repositories/streaming.py
+++ b/app/crate/db/repositories/streaming.py
@@ -229,7 +229,8 @@ def ensure_variant_record(payload: dict) -> dict:
                         ELSE stream_variants.error
                     END,
                     task_id = CASE
-                        WHEN stream_variants.source_path IS DISTINCT FROM EXCLUDED.source_path
+                        WHEN stream_variants.status = 'failed'
+                          OR stream_variants.source_path IS DISTINCT FROM EXCLUDED.source_path
                           OR stream_variants.source_mtime_ns IS DISTINCT FROM EXCLUDED.source_mtime_ns
                           OR stream_variants.source_size IS DISTINCT FROM EXCLUDED.source_size
                         THEN NULL
@@ -338,6 +339,7 @@ def mark_variant_missing(cache_key: str) -> None:
                 """
                 UPDATE stream_variants
                 SET status = 'pending',
+                    task_id = NULL,
                     error = NULL,
                     relative_path = NULL,
                     bytes = NULL,
@@ -383,6 +385,7 @@ def mark_stream_variants_missing(cache_keys: list[str]) -> int:
                 """
                 UPDATE stream_variants
                 SET status = 'pending',
+                    task_id = NULL,
                     error = NULL,
                     relative_path = NULL,
                     bytes = NULL,

--- a/app/listen/src/components/stats/stats-model.ts
+++ b/app/listen/src/components/stats/stats-model.ts
@@ -191,6 +191,17 @@ export interface StatsAffinity {
   affinity_reasons: string[];
 }
 
+export interface StatsSnapshot {
+  scope?: string | null;
+  subject_key?: string | null;
+  version?: number;
+  built_at?: string | null;
+  stale_after?: string | null;
+  stale?: boolean;
+  pending?: boolean;
+  generation_ms?: number;
+}
+
 export interface StatsDashboard {
   window: StatsPeriodKey;
   subject?: StatsSubject | null;
@@ -203,6 +214,7 @@ export interface StatsDashboard {
   replay: ReplayMix;
   story?: StatsStory;
   viewer_affinity?: StatsAffinity | null;
+  snapshot?: StatsSnapshot;
 }
 
 export interface RecapHighlight {

--- a/app/listen/src/hooks/use-pending-stats-snapshot-refresh.test.tsx
+++ b/app/listen/src/hooks/use-pending-stats-snapshot-refresh.test.tsx
@@ -1,0 +1,35 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { usePendingStatsSnapshotRefresh } from "@/hooks/use-pending-stats-snapshot-refresh";
+
+describe("usePendingStatsSnapshotRefresh", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("revalidates while a stats snapshot is pending and stops once it is ready", () => {
+    vi.useFakeTimers();
+    const refetch = vi.fn();
+    const { rerender } = renderHook(
+      ({ pending }) => usePendingStatsSnapshotRefresh(pending, refetch),
+      { initialProps: { pending: true } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1_499);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    rerender({ pending: false });
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/listen/src/hooks/use-pending-stats-snapshot-refresh.ts
+++ b/app/listen/src/hooks/use-pending-stats-snapshot-refresh.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+
+const PENDING_REFRESH_INTERVAL_MS = 1_500;
+const MAX_PENDING_REFRESHES = 40;
+
+export function usePendingStatsSnapshotRefresh(
+  pending: boolean,
+  refetch: () => void,
+): void {
+  const attemptsRef = useRef(0);
+
+  useEffect(() => {
+    if (!pending) {
+      attemptsRef.current = 0;
+      return;
+    }
+
+    attemptsRef.current = 0;
+    const timer = window.setInterval(() => {
+      if (attemptsRef.current >= MAX_PENDING_REFRESHES) {
+        window.clearInterval(timer);
+        return;
+      }
+      attemptsRef.current += 1;
+      refetch();
+    }, PENDING_REFRESH_INTERVAL_MS);
+
+    return () => window.clearInterval(timer);
+  }, [pending, refetch]);
+}

--- a/app/listen/src/pages/Stats.tsx
+++ b/app/listen/src/pages/Stats.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/stats/stats-model";
 import { usePlayerActions } from "@/contexts/PlayerContext";
 import { useApi } from "@/hooks/use-api";
+import { usePendingStatsSnapshotRefresh } from "@/hooks/use-pending-stats-snapshot-refresh";
 import {
   albumCoverApiUrl,
   albumPagePath,
@@ -114,8 +115,16 @@ export function Stats() {
     : username
       ? `/api/users/${encodeURIComponent(username)}/stats/dashboard`
       : "/api/me/stats/dashboard";
-  const { data: dashboard, loading: dashboardLoading } = useApi<StatsDashboard>(
+  const {
+    data: dashboard,
+    loading: dashboardLoading,
+    refetch: refetchDashboard,
+  } = useApi<StatsDashboard>(
     `${statsEndpoint}?${statsPeriodQuery}&tracks_limit=12&artists_limit=10&albums_limit=12&genres_limit=10&replay_limit=36`,
+  );
+  usePendingStatsSnapshotRefresh(
+    dashboard?.snapshot?.pending === true,
+    refetchDashboard,
   );
 
   const overview = dashboard?.overview;

--- a/app/tests/test_stream_cache_maintenance.py
+++ b/app/tests/test_stream_cache_maintenance.py
@@ -268,3 +268,4 @@ def test_streaming_repository_marks_variants_missing_in_one_batch(monkeypatch):
     assert updated == 2
     assert executed[0][1] == {"cache_keys": ["a", "b"]}
     assert "status = 'pending'" in executed[0][0]
+    assert "task_id = NULL" in executed[0][0]

--- a/app/tests/test_streaming_admin.py
+++ b/app/tests/test_streaming_admin.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+
+def test_playback_delivery_snapshot_separates_pending_variant_states(monkeypatch):
+    from crate.db.queries import streaming_admin
+
+    variant_stats = {
+        "variants": 9,
+        "variant_tracks": 4,
+        "ready": 2,
+        "pending": 6,
+        "pending_active": 1,
+        "pending_unassigned": 2,
+        "pending_stale": 3,
+        "running": 0,
+        "failed": 1,
+        "missing": 0,
+        "ready_tracks": 2,
+        "cached_bytes": 100,
+        "ready_source_bytes": 200,
+        "avg_prepare_seconds": 1.5,
+    }
+    executed: list[str] = []
+
+    class Result:
+        def __init__(self, row=None, rows=None):
+            self.row = row
+            self.rows = rows or []
+
+        def mappings(self):
+            return self
+
+        def first(self):
+            return self.row
+
+        def all(self):
+            return self.rows
+
+    class Session:
+        def execute(self, statement, _params=None):
+            query = str(statement)
+            executed.append(query)
+            if len(executed) == 1:
+                return Result(variant_stats)
+            if len(executed) == 2:
+                return Result(
+                    {
+                        "tracks": 4,
+                        "lossless_tracks": 4,
+                        "hires_tracks": 0,
+                    }
+                )
+            return Result(rows=[])
+
+    @contextmanager
+    def scope():
+        yield Session()
+
+    monkeypatch.setattr(streaming_admin, "read_scope", scope)
+
+    snapshot = streaming_admin.get_playback_delivery_snapshot(limit=8)
+
+    assert snapshot["stats"]["pending"] == 6
+    assert snapshot["stats"]["pending_active"] == 1
+    assert snapshot["stats"]["pending_unassigned"] == 2
+    assert snapshot["stats"]["pending_stale"] == 3
+    assert "LEFT JOIN tasks" in executed[0]
+    assert "pending_active" in executed[0]
+    assert "pending_stale" in executed[0]
+
+
+def test_mark_variant_missing_detaches_previous_task(monkeypatch):
+    from crate.db.repositories import streaming
+
+    executed: list[str] = []
+
+    class Session:
+        def execute(self, statement, _params):
+            executed.append(str(statement))
+
+    @contextmanager
+    def scope():
+        yield Session()
+
+    monkeypatch.setattr(streaming, "transaction_scope", scope)
+
+    streaming.mark_variant_missing("cache-key")
+
+    assert "task_id = NULL" in executed[0]

--- a/app/ui/src/pages/SystemHealth.tsx
+++ b/app/ui/src/pages/SystemHealth.tsx
@@ -196,6 +196,9 @@ interface PlaybackDeliveryStats {
   variant_tracks: number;
   ready: number;
   pending: number;
+  pending_active?: number;
+  pending_unassigned?: number;
+  pending_stale?: number;
   running: number;
   failed: number;
   missing: number;
@@ -693,7 +696,21 @@ function PlaybackTranscodingOverview({
   const statuses = [
     { label: "Ready", value: stats?.ready ?? 0, color: "bg-emerald-400" },
     { label: "Running", value: stats?.running ?? 0, color: "bg-cyan-400" },
-    { label: "Pending", value: stats?.pending ?? 0, color: "bg-amber-400" },
+    {
+      label: "Active pending",
+      value: stats?.pending_active ?? stats?.pending ?? 0,
+      color: "bg-amber-400",
+    },
+    {
+      label: "Unassigned",
+      value: stats?.pending_unassigned ?? 0,
+      color: "bg-yellow-300",
+    },
+    {
+      label: "Stale pending",
+      value: stats?.pending_stale ?? 0,
+      color: "bg-orange-500",
+    },
     { label: "Failed", value: stats?.failed ?? 0, color: "bg-red-400" },
     { label: "Missing", value: stats?.missing ?? 0, color: "bg-white/35" },
   ];

--- a/app/ui/src/pages/Tasks.tsx
+++ b/app/ui/src/pages/Tasks.tsx
@@ -175,6 +175,9 @@ interface PlaybackDeliverySnapshot {
     variant_tracks: number;
     ready: number;
     pending: number;
+    pending_active?: number;
+    pending_unassigned?: number;
+    pending_stale?: number;
     running: number;
     failed: number;
     ready_tracks: number;
@@ -1030,7 +1033,17 @@ function PlaybackDeliveryPanel({
           >
             {runtime?.active ?? 0}/{runtime?.limit ?? 1} transcodes
           </CrateChip>
-          <CrateChip>{stats?.pending ?? 0} pending</CrateChip>
+          <CrateChip>
+            {stats?.pending_active ?? stats?.pending ?? 0} active pending
+          </CrateChip>
+          {(stats?.pending_unassigned ?? 0) > 0 ? (
+            <CrateChip>{stats?.pending_unassigned} unassigned</CrateChip>
+          ) : null}
+          {(stats?.pending_stale ?? 0) > 0 ? (
+            <CrateChip className="border-amber-400/25 bg-amber-400/10 text-amber-100">
+              {stats?.pending_stale} stale
+            </CrateChip>
+          ) : null}
           <CrateChip>{stats?.failed ?? 0} failed</CrateChip>
         </div>
         <Button


### PR DESCRIPTION
## Summary
- Revalidate Listen stats while the API returns a cold/pending dashboard snapshot.
- Split playback variant pending counts into active, unassigned, and stale records.
- Clear obsolete variant task IDs when cache artifacts are invalidated or source identity changes.
- Update Admin Tasks and System Health surfaces with the new delivery-state breakdown.

## Verification
- Listen: 17 focused Vitest tests, typecheck, lint, and production build.
- Backend: 15 focused pytest tests and Ruff.
- Admin: typecheck and lint.

The Admin production build remains blocked by the existing local dependency resolution failure for `leaflet/dist/leaflet-src.esm.js`; no dependency changes are included in this hotfix.